### PR TITLE
feat: rebrand Grok CLI to H1DR4 with reasoning and OSINT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,38 @@
-# Grok CLI
+# H1DR4 CLI
 
-A conversational AI CLI tool powered by Grok with intelligent text editor capabilities and tool usage.
+A conversational AI CLI tool powered by H1DR4 with intelligent text editor capabilities and tool usage.
 
 <img width="980" height="435" alt="Screenshot 2025-07-21 at 13 35 41" src="https://github.com/user-attachments/assets/192402e3-30a8-47df-9fc8-a084c5696e78" />
 
 ## Features
 
-- **🤖 Conversational AI**: Natural language interface powered by Grok-3
+- **🤖 Conversational AI**: Natural language interface powered by H1DR4-3
 - **📝 Smart File Operations**: AI automatically uses tools to view, create, and edit files
 - **⚡ Bash Integration**: Execute shell commands through natural conversation
 - **🔧 Automatic Tool Selection**: AI intelligently chooses the right tools for your requests
+- **🧠 Reasoning Engine**: Access a dedicated reasoning endpoint for complex questions
+- **🔍 OSINT Search**: Query public data sources using the `osint_search` tool (set `OSINT_TOKEN`)
 - **🚀 Morph Fast Apply**: Optional high-speed code editing at 4,500+ tokens/sec with 98% accuracy
 - **🔌 MCP Tools**: Extend capabilities with Model Context Protocol servers (Linear, GitHub, etc.)
 - **💬 Interactive UI**: Beautiful terminal interface built with Ink
-- **🌍 Global Installation**: Install and use anywhere with `npm i -g @vibe-kit/grok-cli`
+- **🌍 Global Installation**: Install and use anywhere with `npm i -g @vibe-kit/h1dr4-cli`
 
 ## Installation
 
 ### Prerequisites
-- Node.js 16+ 
+- Node.js 16+
 - Grok API key from X.AI
 - (Optional, Recommended) Morph API key for Fast Apply editing
 
 ### Global Installation (Recommended)
 ```bash
-npm install -g @vibe-kit/grok-cli
+npm install -g @vibe-kit/h1dr4-cli
 ```
 
 ### Local Development
 ```bash
 git clone <repository>
-cd grok-cli
+cd h1dr4-cli
 npm install
 npm run build
 npm link
@@ -55,11 +57,11 @@ cp .env.example .env
 
 **Method 3: Command Line Flag**
 ```bash
-grok --api-key your_api_key_here
+h1dr4 --api-key your_api_key_here
 ```
 
 **Method 4: User Settings File**
-Create `~/.grok/user-settings.json`:
+Create `~/.h1dr4/user-settings.json`:
 ```json
 {
   "apiKey": "your_api_key_here"
@@ -92,11 +94,11 @@ export GROK_BASE_URL=https://your-custom-endpoint.com/v1
 
 **Method 2: Command Line Flag**
 ```bash
-grok --api-key your_api_key_here --base-url https://your-custom-endpoint.com/v1
+h1dr4 --api-key your_api_key_here --base-url https://your-custom-endpoint.com/v1
 ```
 
 **Method 3: User Settings File**
-Add to `~/.grok/user-settings.json`:
+Add to `~/.h1dr4/user-settings.json`:
 ```json
 {
   "apiKey": "your_api_key_here",
@@ -106,9 +108,9 @@ Add to `~/.grok/user-settings.json`:
 
 ## Configuration Files
 
-Grok CLI uses two types of configuration files to manage settings:
+H1DR4 CLI uses two types of configuration files to manage settings:
 
-### User-Level Settings (`~/.grok/user-settings.json`)
+### User-Level Settings (`~/.h1dr4/user-settings.json`)
 
 This file stores **global settings** that apply across all projects. These settings rarely change and include:
 
@@ -132,7 +134,7 @@ This file stores **global settings** that apply across all projects. These setti
 }
 ```
 
-### Project-Level Settings (`.grok/settings.json`)
+### Project-Level Settings (`.h1dr4/settings.json`)
 
 This file stores **project-specific settings** in your current working directory. It includes:
 
@@ -165,10 +167,10 @@ This means you can have different models for different projects while maintainin
 
 ### Using Other API Providers
 
-**Important**: Grok CLI uses **OpenAI-compatible APIs**. You can use any provider that implements the OpenAI chat completions standard.
+**Important**: H1DR4 CLI uses **OpenAI-compatible APIs**. You can use any provider that implements the OpenAI chat completions standard.
 
 **Popular Providers**:
-- **X.AI (Grok)**: `https://api.x.ai/v1` (default)
+- **X.AI (H1DR4)**: `https://api.x.ai/v1` (default)
 - **OpenAI**: `https://api.openai.com/v1`
 - **OpenRouter**: `https://openrouter.ai/api/v1`
 - **Groq**: `https://api.groq.com/openai/v1`
@@ -193,22 +195,22 @@ This means you can have different models for different projects while maintainin
 
 Start the conversational AI assistant:
 ```bash
-grok
+h1dr4
 ```
 
 Or specify a working directory:
 ```bash
-grok -d /path/to/project
+h1dr4 -d /path/to/project
 ```
 
 ### Headless Mode
 
 Process a single prompt and exit (useful for scripting and automation):
 ```bash
-grok --prompt "show me the package.json file"
-grok -p "create a new file called example.js with a hello world function"
-grok --prompt "run npm test and show me the results" --directory /path/to/project
-grok --prompt "complex task" --max-tool-rounds 50  # Limit tool usage for faster execution
+h1dr4 --prompt "show me the package.json file"
+h1dr4 -p "create a new file called example.js with a hello world function"
+h1dr4 --prompt "run npm test and show me the results" --directory /path/to/project
+h1dr4 --prompt "complex task" --max-tool-rounds 50  # Limit tool usage for faster execution
 ```
 
 This mode is particularly useful for:
@@ -219,18 +221,18 @@ This mode is particularly useful for:
 
 ### Tool Execution Control
 
-By default, Grok CLI allows up to 400 tool execution rounds to handle complex multi-step tasks. You can control this behavior:
+By default, H1DR4 CLI allows up to 400 tool execution rounds to handle complex multi-step tasks. You can control this behavior:
 
 ```bash
 # Limit tool rounds for faster execution on simple tasks
-grok --max-tool-rounds 10 --prompt "show me the current directory"
+h1dr4 --max-tool-rounds 10 --prompt "show me the current directory"
 
 # Increase limit for very complex tasks (use with caution)
-grok --max-tool-rounds 1000 --prompt "comprehensive code refactoring"
+h1dr4 --max-tool-rounds 1000 --prompt "comprehensive code refactoring"
 
 # Works with all modes
-grok --max-tool-rounds 20  # Interactive mode
-grok git commit-and-push --max-tool-rounds 30  # Git commands
+h1dr4 --max-tool-rounds 20  # Interactive mode
+h1dr4 git commit-and-push --max-tool-rounds 30  # Git commands
 ```
 
 **Use Cases**:
@@ -240,28 +242,29 @@ grok git commit-and-push --max-tool-rounds 30  # Git commands
 
 ### Model Selection
 
-You can specify which AI model to use with the `--model` parameter or `GROK_MODEL` environment variable:
+You can specify which AI model to use with the `--model` parameter or `H1DR4_MODEL` environment variable:
 
 **Method 1: Command Line Flag**
 ```bash
-# Use Grok models
-grok --model grok-4-latest
-grok --model grok-3-latest
-grok --model grok-3-fast
+# Use H1DR4 models
+h1dr4 --model grok-4-latest
+h1dr4 --model grok-3-latest
+h1dr4 --model grok-3-fast
 
 # Use other models (with appropriate API endpoint)
-grok --model gemini-2.5-pro --base-url https://api-endpoint.com/v1
-grok --model claude-sonnet-4-20250514 --base-url https://api-endpoint.com/v1
+h1dr4 --model gemini-2.5-pro --base-url https://api-endpoint.com/v1
+h1dr4 --model claude-sonnet-4-20250514 --base-url https://api-endpoint.com/v1
 ```
 
 **Method 2: Environment Variable**
 ```bash
-export GROK_MODEL=grok-4-latest
-grok
+export H1DR4_MODEL=grok-4-latest
+export OSINT_TOKEN=your_osint_token_here
+h1dr4
 ```
 
 **Method 3: User Settings File**
-Add to `~/.grok/user-settings.json`:
+Add to `~/.h1dr4/user-settings.json`:
 ```json
 {
   "apiKey": "your_api_key_here",
@@ -269,19 +272,19 @@ Add to `~/.grok/user-settings.json`:
 }
 ```
 
-**Model Priority**: `--model` flag > `GROK_MODEL` environment variable > user default model > system default (grok-4-latest)
+**Model Priority**: `--model` flag > `H1DR4_MODEL` environment variable > user default model > system default (grok-4-latest)
 
 ### Command Line Options
 
 ```bash
-grok [options]
+h1dr4 [options]
 
 Options:
   -V, --version          output the version number
   -d, --directory <dir>  set working directory
   -k, --api-key <key>    Grok API key (or set GROK_API_KEY env var)
   -u, --base-url <url>   Grok API base URL (or set GROK_BASE_URL env var)
-  -m, --model <model>    AI model to use (e.g., grok-4-latest, grok-3-latest) (or set GROK_MODEL env var)
+  -m, --model <model>    AI model to use (e.g., grok-4-latest, grok-3-latest) (or set H1DR4_MODEL env var)
   -p, --prompt <prompt>  process a single prompt and exit (headless mode)
   --max-tool-rounds <rounds>  maximum number of tool execution rounds (default: 400)
   -h, --help             display help for command
@@ -289,15 +292,15 @@ Options:
 
 ### Custom Instructions
 
-You can provide custom instructions to tailor Grok's behavior to your project by creating a `.grok/GROK.md` file in your project directory:
+You can provide custom instructions to tailor H1DR4's behavior to your project by creating a `.h1dr4/H1DR4.md` file in your project directory:
 
 ```bash
-mkdir .grok
+mkdir .h1dr4
 ```
 
-Create `.grok/GROK.md` with your custom instructions:
+Create `.h1dr4/H1DR4.md` with your custom instructions:
 ```markdown
-# Custom Instructions for Grok CLI
+# Custom Instructions for H1DR4 CLI
 
 Always use TypeScript for any new code files.
 When creating React components, use functional components with hooks.
@@ -306,11 +309,11 @@ Always add JSDoc comments for public functions and interfaces.
 Follow the existing code style and patterns in this project.
 ```
 
-Grok will automatically load and follow these instructions when working in your project directory. The custom instructions are added to Grok's system prompt and take priority over default behavior.
+H1DR4 will automatically load and follow these instructions when working in your project directory. The custom instructions are added to H1DR4's system prompt and take priority over default behavior.
 
 ## Morph Fast Apply (Optional)
 
-Grok CLI supports Morph's Fast Apply model for high-speed code editing at **4,500+ tokens/sec with 98% accuracy**. This is an optional feature that provides lightning-fast file editing capabilities.
+H1DR4 CLI supports Morph's Fast Apply model for high-speed code editing at **4,500+ tokens/sec with 98% accuracy**. This is an optional feature that provides lightning-fast file editing capabilities.
 
 **Setup**: Configure your Morph API key following the [setup instructions](#setup) above.
 
@@ -331,33 +334,33 @@ When `MORPH_API_KEY` is configured:
 With Morph Fast Apply configured, you can request complex code changes:
 
 ```bash
-grok --prompt "refactor this function to use async/await and add error handling"
-grok -p "convert this class to TypeScript and add proper type annotations"
+h1dr4 --prompt "refactor this function to use async/await and add error handling"
+h1dr4 -p "convert this class to TypeScript and add proper type annotations"
 ```
 
 The AI will automatically choose between `edit_file` (Morph) for complex changes or `str_replace_editor` for simple replacements.
 
 ## MCP Tools
 
-Grok CLI supports MCP (Model Context Protocol) servers, allowing you to extend the AI assistant with additional tools and capabilities.
+H1DR4 CLI supports MCP (Model Context Protocol) servers, allowing you to extend the AI assistant with additional tools and capabilities.
 
 ### Adding MCP Tools
 
 #### Add a custom MCP server:
 ```bash
 # Add an stdio-based MCP server
-grok mcp add my-server --transport stdio --command "node" --args server.js
+h1dr4 mcp add my-server --transport stdio --command "node" --args server.js
 
 # Add an HTTP-based MCP server
-grok mcp add my-server --transport http --url "http://localhost:3000"
+h1dr4 mcp add my-server --transport http --url "http://localhost:3000"
 
 # Add with environment variables
-grok mcp add my-server --transport stdio --command "python" --args "-m" "my_mcp_server" --env "API_KEY=your_key"
+h1dr4 mcp add my-server --transport stdio --command "python" --args "-m" "my_mcp_server" --env "API_KEY=your_key"
 ```
 
 #### Add from JSON configuration:
 ```bash
-grok mcp add-json my-server '{"command": "node", "args": ["server.js"], "env": {"API_KEY": "your_key"}}'
+h1dr4 mcp add-json my-server '{"command": "node", "args": ["server.js"], "env": {"API_KEY": "your_key"}}'
 ```
 
 ### Linear Integration Example
@@ -366,7 +369,7 @@ To add Linear MCP tools for project management:
 
 ```bash
 # Add Linear MCP server
-grok mcp add linear --transport sse --url "https://mcp.linear.app/sse"
+h1dr4 mcp add linear --transport sse --url "https://mcp.linear.app/sse"
 ```
 
 This enables Linear tools like:
@@ -379,13 +382,13 @@ This enables Linear tools like:
 
 ```bash
 # List all configured servers
-grok mcp list
+h1dr4 mcp list
 
 # Test server connection
-grok mcp test server-name
+h1dr4 mcp test server-name
 
 # Remove a server
-grok mcp remove server-name
+h1dr4 mcp remove server-name
 ```
 
 ### Available Transport Types

--- a/grok.mkd
+++ b/grok.mkd
@@ -1,0 +1,4 @@
+# H1DR4 Persona
+
+H1DR4 is a vigilant open-source intelligence agent designed to assist users via the H1DR4 CLI.
+It emphasizes clear reasoning, security awareness, and personalized interactions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@vibe-kit/grok-cli",
+  "name": "@vibe-kit/h1dr4-cli",
   "version": "0.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@vibe-kit/grok-cli",
+      "name": "@vibe-kit/h1dr4-cli",
       "version": "0.0.17",
       "license": "MIT",
       "dependencies": {
@@ -25,7 +25,7 @@
         "tiktoken": "^1.0.21"
       },
       "bin": {
-        "grok": "dist/index.js"
+        "h1dr4": "dist/index.js"
       },
       "devDependencies": {
         "@types/fs-extra": "^11.0.2",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@vibe-kit/grok-cli",
+  "name": "@vibe-kit/h1dr4-cli",
   "version": "0.0.23",
-  "description": "An open-source AI agent that brings the power of Grok directly into your terminal.",
+  "description": "An open-source AI agent that brings the power of H1DR4 directly into your terminal.",
   "main": "dist/index.js",
   "bin": {
-    "grok": "dist/index.js"
+    "h1dr4": "dist/index.js"
   },
   "scripts": {
     "build": "tsc",
@@ -17,7 +17,7 @@
     "cli",
     "agent",
     "text-editor",
-    "grok",
+    "h1dr4",
     "ai"
   ],
   "author": "Your Name",

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -1,6 +1,6 @@
 import { Command } from 'commander';
 import { addMCPServer, removeMCPServer, loadMCPConfig, PREDEFINED_SERVERS } from '../mcp/config';
-import { getMCPManager } from '../grok/tools';
+import { getMCPManager } from '../h1dr4/tools';
 import { MCPServerConfig } from '../mcp/client';
 import chalk from 'chalk';
 

--- a/src/h1dr4/client.ts
+++ b/src/h1dr4/client.ts
@@ -1,9 +1,9 @@
 import OpenAI from "openai";
 import type { ChatCompletionMessageParam } from "openai/resources/chat";
 
-export type GrokMessage = ChatCompletionMessageParam;
+export type H1dr4Message = ChatCompletionMessageParam;
 
-export interface GrokTool {
+export interface H1dr4Tool {
   type: "function";
   function: {
     name: string;
@@ -16,7 +16,7 @@ export interface GrokTool {
   };
 }
 
-export interface GrokToolCall {
+export interface H1dr4ToolCall {
   id: string;
   type: "function";
   function: {
@@ -34,18 +34,18 @@ export interface SearchOptions {
   search_parameters?: SearchParameters;
 }
 
-export interface GrokResponse {
+export interface H1dr4Response {
   choices: Array<{
     message: {
       role: string;
       content: string | null;
-      tool_calls?: GrokToolCall[];
+      tool_calls?: H1dr4ToolCall[];
     };
     finish_reason: string;
   }>;
 }
 
-export class GrokClient {
+export class H1dr4Client {
   private client: OpenAI;
   private currentModel: string = "grok-3-latest";
 
@@ -69,11 +69,11 @@ export class GrokClient {
   }
 
   async chat(
-    messages: GrokMessage[],
-    tools?: GrokTool[],
+    messages: H1dr4Message[],
+    tools?: H1dr4Tool[],
     model?: string,
     searchOptions?: SearchOptions
-  ): Promise<GrokResponse> {
+  ): Promise<H1dr4Response> {
     try {
       const requestPayload: any = {
         model: model || this.currentModel,
@@ -93,15 +93,15 @@ export class GrokClient {
         requestPayload
       );
 
-      return response as GrokResponse;
+      return response as H1dr4Response;
     } catch (error: any) {
-      throw new Error(`Grok API error: ${error.message}`);
+      throw new Error(`H1dr4 API error: ${error.message}`);
     }
   }
 
   async *chatStream(
-    messages: GrokMessage[],
-    tools?: GrokTool[],
+    messages: H1dr4Message[],
+    tools?: H1dr4Tool[],
     model?: string,
     searchOptions?: SearchOptions
   ): AsyncGenerator<any, void, unknown> {
@@ -129,15 +129,28 @@ export class GrokClient {
         yield chunk;
       }
     } catch (error: any) {
-      throw new Error(`Grok API error: ${error.message}`);
+      throw new Error(`H1dr4 API error: ${error.message}`);
+    }
+  }
+
+  async reason(prompt: string, model?: string): Promise<string> {
+    try {
+      const response: any = await (this.client as any).responses.create({
+        model: model || this.currentModel,
+        input: prompt,
+        reasoning: { effort: "medium" },
+      });
+      return response.output_text;
+    } catch (error: any) {
+      throw new Error(`H1dr4 reasoning error: ${error.message}`);
     }
   }
 
   async search(
     query: string,
     searchParameters?: SearchParameters
-  ): Promise<GrokResponse> {
-    const searchMessage: GrokMessage = {
+  ): Promise<H1dr4Response> {
+    const searchMessage: H1dr4Message = {
       role: "user",
       content: query,
     };

--- a/src/h1dr4/tools.ts
+++ b/src/h1dr4/tools.ts
@@ -1,8 +1,8 @@
-import { GrokTool } from "./client";
+import { H1dr4Tool } from "./client";
 import { MCPManager, MCPTool } from "../mcp/client";
 import { loadMCPConfig } from "../mcp/config";
 
-const BASE_GROK_TOOLS: GrokTool[] = [
+const BASE_H1DR4_TOOLS: H1dr4Tool[] = [
   {
     type: "function",
     function: {
@@ -241,10 +241,44 @@ const BASE_GROK_TOOLS: GrokTool[] = [
       },
     },
   },
+  {
+    type: "function",
+    function: {
+      name: "osint_search",
+      description: "Perform OSINT targeted search for defined entities",
+      parameters: {
+        type: "object",
+        properties: {
+          query: {
+            type: "string",
+            description: "Search query for the OSINT endpoint",
+          },
+        },
+        required: ["query"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "reason",
+      description: "Use a dedicated reasoning model for complex questions",
+      parameters: {
+        type: "object",
+        properties: {
+          prompt: {
+            type: "string",
+            description: "Question or instruction requiring deep reasoning",
+          },
+        },
+        required: ["prompt"],
+      },
+    },
+  },
 ];
 
 // Morph Fast Apply tool (conditional)
-const MORPH_EDIT_TOOL: GrokTool = {
+const MORPH_EDIT_TOOL: H1dr4Tool = {
   type: "function",
   function: {
     name: "edit_file",
@@ -271,8 +305,8 @@ const MORPH_EDIT_TOOL: GrokTool = {
 };
 
 // Function to build tools array conditionally
-function buildGrokTools(): GrokTool[] {
-  const tools = [...BASE_GROK_TOOLS];
+function buildH1dr4Tools(): H1dr4Tool[] {
+  const tools = [...BASE_H1DR4_TOOLS];
   
   // Add Morph Fast Apply tool if API key is available
   if (process.env.MORPH_API_KEY) {
@@ -283,7 +317,7 @@ function buildGrokTools(): GrokTool[] {
 }
 
 // Export dynamic tools array
-export const GROK_TOOLS: GrokTool[] = buildGrokTools();
+export const H1DR4_TOOLS: H1dr4Tool[] = buildH1dr4Tools();
 
 // Global MCP manager instance
 let mcpManager: MCPManager | null = null;
@@ -339,7 +373,7 @@ export async function initializeMCPServers(): Promise<void> {
   }
 }
 
-export function convertMCPToolToGrokTool(mcpTool: MCPTool): GrokTool {
+export function convertMCPToolToH1dr4Tool(mcpTool: MCPTool): H1dr4Tool {
   return {
     type: "function",
     function: {
@@ -354,22 +388,22 @@ export function convertMCPToolToGrokTool(mcpTool: MCPTool): GrokTool {
   };
 }
 
-export function addMCPToolsToGrokTools(baseTools: GrokTool[]): GrokTool[] {
+export function addMCPToolsToH1dr4Tools(baseTools: H1dr4Tool[]): H1dr4Tool[] {
   if (!mcpManager) {
     return baseTools;
   }
   
   const mcpTools = mcpManager.getTools();
-  const grokMCPTools = mcpTools.map(convertMCPToolToGrokTool);
+  const h1dr4MCPTools = mcpTools.map(convertMCPToolToH1dr4Tool);
   
-  return [...baseTools, ...grokMCPTools];
+  return [...baseTools, ...h1dr4MCPTools];
 }
 
-export async function getAllGrokTools(): Promise<GrokTool[]> {
+export async function getAllH1dr4Tools(): Promise<H1dr4Tool[]> {
   const manager = getMCPManager();
   // Try to initialize servers if not already done, but don't block
   manager.ensureServersInitialized().catch(() => {
     // Ignore initialization errors to avoid blocking
   });
-  return addMCPToolsToGrokTools(GROK_TOOLS);
+  return addMCPToolsToH1dr4Tools(H1DR4_TOOLS);
 }

--- a/src/hooks/use-input-handler.ts
+++ b/src/hooks/use-input-handler.ts
@@ -1,6 +1,6 @@
 import { useState, useMemo, useEffect } from "react";
 import { useInput } from "ink";
-import { GrokAgent, ChatEntry } from "../agent/grok-agent";
+import { H1dr4Agent, ChatEntry } from "../agent/h1dr4-agent";
 import { ConfirmationService } from "../utils/confirmation-service";
 import { useEnhancedInput, Key } from "./use-enhanced-input";
 
@@ -8,7 +8,7 @@ import { filterCommandSuggestions } from "../ui/components/command-suggestions";
 import { loadModelConfig, updateCurrentModel } from "../utils/model-config";
 
 interface UseInputHandlerProps {
-  agent: GrokAgent;
+  agent: H1dr4Agent;
   chatHistory: ChatEntry[];
   setChatHistory: React.Dispatch<React.SetStateAction<ChatEntry[]>>;
   setIsProcessing: (processing: boolean) => void;
@@ -222,7 +222,7 @@ export function useInputHandler({
   const commandSuggestions: CommandSuggestion[] = [
     { command: "/help", description: "Show help information" },
     { command: "/clear", description: "Clear chat history" },
-    { command: "/models", description: "Switch Grok Model" },
+    { command: "/models", description: "Switch H1dr4 Model" },
     { command: "/commit-and-push", description: "AI commit & push to remote" },
     { command: "/exit", description: "Exit the application" },
   ];
@@ -258,7 +258,7 @@ export function useInputHandler({
     if (trimmedInput === "/help") {
       const helpEntry: ChatEntry = {
         type: "assistant",
-        content: `Grok CLI Help:
+        content: `H1dr4 CLI Help:
 
 Built-in Commands:
   /clear      - Clear chat history
@@ -289,7 +289,7 @@ Direct Commands (executed immediately):
   touch <file>- Create empty file
 
 Model Configuration:
-  Edit ~/.grok/models.json to add custom models (Claude, GPT, Gemini, etc.)
+  Edit ~/.h1dr4/models.json to add custom models (Claude, GPT, Gemini, etc.)
 
 For complex operations, just describe what you want in natural language.
 Examples:

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import React from "react";
 import { render } from "ink";
 import { program } from "commander";
 import * as dotenv from "dotenv";
-import { GrokAgent } from "./agent/grok-agent";
+import { H1dr4Agent } from "./agent/h1dr4-agent";
 import ChatInterface from "./ui/components/chat-interface";
 import { getSettingsManager } from "./utils/settings-manager";
 import { ConfirmationService } from "./utils/confirmation-service";
@@ -72,11 +72,11 @@ async function saveCommandLineSettings(apiKey?: string, baseURL?: string): Promi
     // Update with command line values
     if (apiKey) {
       manager.updateUserSetting('apiKey', apiKey);
-      console.log("✅ API key saved to ~/.grok/user-settings.json");
+      console.log("✅ API key saved to ~/.h1dr4/user-settings.json");
     }
     if (baseURL) {
       manager.updateUserSetting('baseURL', baseURL);
-      console.log("✅ Base URL saved to ~/.grok/user-settings.json");
+      console.log("✅ Base URL saved to ~/.h1dr4/user-settings.json");
     }
   } catch (error) {
     console.warn("⚠️ Could not save settings to file:", error instanceof Error ? error.message : "Unknown error");
@@ -86,7 +86,7 @@ async function saveCommandLineSettings(apiKey?: string, baseURL?: string): Promi
 // Load model from user settings if not in environment
 function loadModel(): string | undefined {
   // First check environment variables
-  let model = process.env.GROK_MODEL;
+  let model = process.env.H1DR4_MODEL;
 
   if (!model) {
     // Use the unified model loading from settings manager
@@ -109,7 +109,7 @@ async function handleCommitAndPushHeadless(
   maxToolRounds?: number
 ): Promise<void> {
   try {
-    const agent = new GrokAgent(apiKey, baseURL, model, maxToolRounds);
+    const agent = new H1dr4Agent(apiKey, baseURL, model, maxToolRounds);
 
     // Configure confirmation service for headless mode (auto-approve all operations)
     const confirmationService = ConfirmationService.getInstance();
@@ -231,7 +231,7 @@ async function processPromptHeadless(
   maxToolRounds?: number
 ): Promise<void> {
   try {
-    const agent = new GrokAgent(apiKey, baseURL, model, maxToolRounds);
+    const agent = new H1dr4Agent(apiKey, baseURL, model, maxToolRounds);
 
     // Configure confirmation service for headless mode (auto-approve all operations)
     const confirmationService = ConfirmationService.getInstance();
@@ -302,9 +302,9 @@ async function processPromptHeadless(
 }
 
 program
-  .name("grok")
+  .name("h1dr4")
   .description(
-    "A conversational AI CLI tool powered by Grok with text editor capabilities"
+    "A conversational AI CLI tool powered by H1dr4 with text editor capabilities"
   )
   .version("1.0.1")
   .option("-d, --directory <dir>", "set working directory", process.cwd())
@@ -315,7 +315,7 @@ program
   )
   .option(
     "-m, --model <model>",
-    "AI model to use (e.g., gemini-2.5-pro, grok-4-latest) (or set GROK_MODEL env var)"
+    "AI model to use (e.g., gemini-2.5-pro, grok-4-latest) (or set H1DR4_MODEL env var)"
   )
   .option(
     "-p, --prompt <prompt>",
@@ -348,7 +348,7 @@ program
 
       if (!apiKey) {
         console.error(
-          "❌ Error: API key required. Set GROK_API_KEY environment variable, use --api-key flag, or save to ~/.grok/user-settings.json"
+          "❌ Error: API key required. Set GROK_API_KEY environment variable, use --api-key flag, or save to ~/.h1dr4/user-settings.json"
         );
         process.exit(1);
       }
@@ -365,14 +365,14 @@ program
       }
 
       // Interactive mode: launch UI
-      const agent = new GrokAgent(apiKey, baseURL, model, maxToolRounds);
-      console.log("🤖 Starting Grok CLI Conversational Assistant...\n");
+      const agent = new H1dr4Agent(apiKey, baseURL, model, maxToolRounds);
+      console.log("🤖 Starting H1dr4 CLI Conversational Assistant...\n");
 
       ensureUserSettingsDirectory();
 
       render(React.createElement(ChatInterface, { agent }));
     } catch (error: any) {
-      console.error("❌ Error initializing Grok CLI:", error.message);
+      console.error("❌ Error initializing H1dr4 CLI:", error.message);
       process.exit(1);
     }
   });
@@ -393,7 +393,7 @@ gitCommand
   )
   .option(
     "-m, --model <model>",
-    "AI model to use (e.g., gemini-2.5-pro, grok-4-latest) (or set GROK_MODEL env var)"
+    "AI model to use (e.g., gemini-2.5-pro, grok-4-latest) (or set H1DR4_MODEL env var)"
   )
   .option(
     "--max-tool-rounds <rounds>",
@@ -422,7 +422,7 @@ gitCommand
 
       if (!apiKey) {
         console.error(
-          "❌ Error: API key required. Set GROK_API_KEY environment variable, use --api-key flag, or save to ~/.grok/user-settings.json"
+          "❌ Error: API key required. Set GROK_API_KEY environment variable, use --api-key flag, or save to ~/.h1dr4/user-settings.json"
         );
         process.exit(1);
       }

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -48,7 +48,7 @@ export class MCPManager extends EventEmitter {
       // Create client
       const client = new Client(
         {
-          name: "grok-cli",
+          name: "h1dr4-cli",
           version: "1.0.0"
         },
         {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4,3 +4,4 @@ export { MorphEditorTool } from "./morph-editor";
 export { TodoTool } from "./todo-tool";
 export { ConfirmationTool } from "./confirmation-tool";
 export { SearchTool } from "./search";
+export { OSINTTool } from "./osint";

--- a/src/tools/osint.ts
+++ b/src/tools/osint.ts
@@ -1,0 +1,24 @@
+import axios from "axios";
+import { ToolResult } from "../types";
+
+export class OSINTTool {
+  async search(query: string): Promise<ToolResult> {
+    try {
+      const token = process.env.OSINT_TOKEN;
+      if (!token) {
+        return { success: false, error: "OSINT_TOKEN environment variable not set" };
+      }
+
+      const r = await axios.post('https://my-search-proxy.ew.r.appspot.com/leakosint', {
+        token,
+        request: query,
+        limit: 100,
+        lang: 'en',
+      });
+
+      return { success: true, output: JSON.stringify(r.data, null, 2) };
+    } catch (err: any) {
+      return { success: false, error: 'Error performing search. Please try again.' };
+    }
+  }
+}

--- a/src/ui/app.tsx
+++ b/src/ui/app.tsx
@@ -124,7 +124,7 @@ export default function App({ agent }: Props) {
     <Box flexDirection="column" padding={1}>
       <Box marginBottom={1}>
         <Text bold color="cyan">
-          🔧 Grok CLI - Text Editor Agent
+          🔧 H1dr4 CLI - Text Editor Agent
         </Text>
       </Box>
       

--- a/src/ui/components/api-key-input.tsx
+++ b/src/ui/components/api-key-input.tsx
@@ -1,10 +1,10 @@
 import React, { useState } from "react";
 import { Box, Text, useInput, useApp } from "ink";
-import { GrokAgent } from "../../agent/grok-agent";
+import { H1dr4Agent } from "../../agent/h1dr4-agent";
 import { getSettingsManager } from "../../utils/settings-manager";
 
 interface ApiKeyInputProps {
-  onApiKeySet: (agent: GrokAgent) => void;
+  onApiKeySet: (agent: H1dr4Agent) => void;
 }
 
 export default function ApiKeyInput({ onApiKeySet }: ApiKeyInputProps) {
@@ -49,8 +49,8 @@ export default function ApiKeyInput({ onApiKeySet }: ApiKeyInputProps) {
     setIsSubmitting(true);
     try {
       const apiKey = input.trim();
-      const agent = new GrokAgent(apiKey);
-      
+      const agent = new H1dr4Agent(apiKey);
+
       // Set environment variable for current process
       process.env.GROK_API_KEY = apiKey;
       
@@ -58,7 +58,7 @@ export default function ApiKeyInput({ onApiKeySet }: ApiKeyInputProps) {
       try {
         const manager = getSettingsManager();
         manager.updateUserSetting('apiKey', apiKey);
-        console.log(`\n✅ API key saved to ~/.grok/user-settings.json`);
+        console.log(`\n✅ API key saved to ~/.h1dr4/user-settings.json`);
       } catch (error) {
         console.log('\n⚠️ Could not save API key to settings file');
         console.log('API key set for current session only');
@@ -96,7 +96,7 @@ export default function ApiKeyInput({ onApiKeySet }: ApiKeyInputProps) {
       <Box flexDirection="column" marginTop={1}>
         <Text color="gray" dimColor>• Press Enter to submit</Text>
         <Text color="gray" dimColor>• Press Ctrl+C to exit</Text>
-        <Text color="gray" dimColor>Note: API key will be saved to ~/.grok/user-settings.json</Text>
+        <Text color="gray" dimColor>Note: API key will be saved to ~/.h1dr4/user-settings.json</Text>
       </Box>
 
       {isSubmitting ? (

--- a/src/ui/components/chat-history.tsx
+++ b/src/ui/components/chat-history.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Box, Text } from "ink";
-import { ChatEntry } from "../../agent/grok-agent";
+import { ChatEntry } from "../../agent/h1dr4-agent";
 import { DiffRenderer } from "./diff-renderer";
 import { MarkdownRenderer } from "../utils/markdown-renderer";
 

--- a/src/ui/components/chat-interface.tsx
+++ b/src/ui/components/chat-interface.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import { Box, Text } from "ink";
-import { GrokAgent, ChatEntry } from "../../agent/grok-agent";
+import { H1dr4Agent, ChatEntry } from "../../agent/h1dr4-agent";
 import { useInputHandler } from "../../hooks/use-input-handler";
 import { LoadingSpinner } from "./loading-spinner";
 import { CommandSuggestions } from "./command-suggestions";
@@ -17,11 +17,11 @@ import ApiKeyInput from "./api-key-input";
 import cfonts from "cfonts";
 
 interface ChatInterfaceProps {
-  agent?: GrokAgent;
+  agent?: H1dr4Agent;
 }
 
 // Main chat component that handles input when agent is available
-function ChatInterfaceWithAgent({ agent }: { agent: GrokAgent }) {
+function ChatInterfaceWithAgent({ agent }: { agent: H1dr4Agent }) {
   const [chatHistory, setChatHistory] = useState<ChatEntry[]>([]);
   const [isProcessing, setIsProcessing] = useState(false);
   const [processingTime, setProcessingTime] = useState(0);
@@ -74,7 +74,7 @@ function ChatInterfaceWithAgent({ agent }: { agent: GrokAgent }) {
     console.log("    ");
 
     // Generate logo with margin to match Ink paddingX={2}
-    const logoOutput = cfonts.render("GROK", {
+    const logoOutput = cfonts.render("H1DR4", {
       font: "3d",
       align: "left",
       colors: ["magenta", "gray"],
@@ -166,7 +166,7 @@ function ChatInterfaceWithAgent({ agent }: { agent: GrokAgent }) {
             </Text>
             <Text color="gray">2. Be specific for the best results.</Text>
             <Text color="gray">
-              3. Create GROK.md files to customize your interactions with Grok.
+              3. Create H1DR4.md files to customize your interactions with H1dr4.
             </Text>
             <Text color="gray">
               4. Press Shift+Tab to toggle auto-edit mode.
@@ -251,11 +251,11 @@ function ChatInterfaceWithAgent({ agent }: { agent: GrokAgent }) {
 
 // Main component that handles API key input or chat interface
 export default function ChatInterface({ agent }: ChatInterfaceProps) {
-  const [currentAgent, setCurrentAgent] = useState<GrokAgent | null>(
+  const [currentAgent, setCurrentAgent] = useState<H1dr4Agent | null>(
     agent || null
   );
 
-  const handleApiKeySet = (newAgent: GrokAgent) => {
+  const handleApiKeySet = (newAgent: H1dr4Agent) => {
     setCurrentAgent(newAgent);
   };
 

--- a/src/ui/components/mcp-status.tsx
+++ b/src/ui/components/mcp-status.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Box, Text } from "ink";
-import { getMCPManager } from "../../grok/tools";
+import { getMCPManager } from "../../h1dr4/tools";
 import { MCPTool } from "../../mcp/client";
 
 interface MCPStatusProps {}

--- a/src/ui/components/model-selection.tsx
+++ b/src/ui/components/model-selection.tsx
@@ -23,7 +23,7 @@ export function ModelSelection({
   return (
     <Box marginTop={1} flexDirection="column">
       <Box marginBottom={1}>
-        <Text color="cyan">Select Grok Model (current: {currentModel}):</Text>
+        <Text color="cyan">Select H1DR4 Model (current: {currentModel}):</Text>
       </Box>
       {models.map((modelOption, index) => (
         <Box key={index} paddingLeft={1}>

--- a/src/utils/custom-instructions.ts
+++ b/src/utils/custom-instructions.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 
 export function loadCustomInstructions(workingDirectory: string = process.cwd()): string | null {
   try {
-    const instructionsPath = path.join(workingDirectory, '.grok', 'GROK.md');
+    const instructionsPath = path.join(workingDirectory, '.h1dr4', 'H1DR4.md');
     
     if (!fs.existsSync(instructionsPath)) {
       return null;

--- a/src/utils/settings-manager.ts
+++ b/src/utils/settings-manager.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as os from 'os';
 
 /**
- * User-level settings stored in ~/.grok/user-settings.json
+ * User-level settings stored in ~/.h1dr4/user-settings.json
  * These are global settings that apply across all projects
  */
 export interface UserSettings {
@@ -14,7 +14,7 @@ export interface UserSettings {
 }
 
 /**
- * Project-level settings stored in .grok/settings.json
+ * Project-level settings stored in .h1dr4/settings.json
  * These are project-specific settings
  */
 export interface ProjectSettings {
@@ -53,11 +53,11 @@ export class SettingsManager {
   private projectSettingsPath: string;
   
   private constructor() {
-    // User settings path: ~/.grok/user-settings.json
-    this.userSettingsPath = path.join(os.homedir(), '.grok', 'user-settings.json');
+    // User settings path: ~/.h1dr4/user-settings.json
+    this.userSettingsPath = path.join(os.homedir(), '.h1dr4', 'user-settings.json');
     
-    // Project settings path: .grok/settings.json (in current working directory)
-    this.projectSettingsPath = path.join(process.cwd(), '.grok', 'settings.json');
+    // Project settings path: .h1dr4/settings.json (in current working directory)
+    this.projectSettingsPath = path.join(process.cwd(), '.h1dr4', 'settings.json');
   }
   
   /**
@@ -81,7 +81,7 @@ export class SettingsManager {
   }
   
   /**
-   * Load user settings from ~/.grok/user-settings.json
+   * Load user settings from ~/.h1dr4/user-settings.json
    */
   public loadUserSettings(): UserSettings {
     try {
@@ -103,7 +103,7 @@ export class SettingsManager {
   }
   
   /**
-   * Save user settings to ~/.grok/user-settings.json
+   * Save user settings to ~/.h1dr4/user-settings.json
    */
   public saveUserSettings(settings: Partial<UserSettings>): void {
     try {
@@ -152,7 +152,7 @@ export class SettingsManager {
   }
   
   /**
-   * Load project settings from .grok/settings.json
+   * Load project settings from .h1dr4/settings.json
    */
   public loadProjectSettings(): ProjectSettings {
     try {
@@ -174,7 +174,7 @@ export class SettingsManager {
   }
   
   /**
-   * Save project settings to .grok/settings.json
+   * Save project settings to .h1dr4/settings.json
    */
   public saveProjectSettings(settings: Partial<ProjectSettings>): void {
     try {


### PR DESCRIPTION
## Summary
- rebrand Grok CLI to H1DR4 across code, docs and settings
- add reasoning endpoint and OSINT search tool with env-driven token
- document H1DR4 persona and new features
- retain Grok API key and endpoint naming for authentication

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a766f09844832c9d4f6736126344ce