### PR TITLE
feat: stream todo updates asynchronously

### DIFF
--- a/src/ui/components/chat-interface.tsx
+++ b/src/ui/components/chat-interface.tsx
@@ -102,6 +102,16 @@ function ChatInterfaceWithAgent({ agent }: { agent: H1dr4Agent }) {
   }, []);
 
   useEffect(() => {
+    const handler = (entry: ChatEntry) => {
+      setChatHistory((prev) => [...prev, entry]);
+    };
+    agent.on("chat_entry", handler);
+    return () => {
+      agent.off("chat_entry", handler);
+    };
+  }, [agent]);
+
+  useEffect(() => {
     const handleConfirmationRequest = (options: ConfirmationOptions) => {
       setConfirmationOptions(options);
     };


### PR DESCRIPTION
## Summary
- stream incremental todo updates via EventEmitter so plans update live
- push todo updates into chat history for real-time planning adjustments

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7da514020832c92cf5e2130759a92