### PR TITLE
feat: support live plan updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,10 @@ Or specify a working directory:
 h1dr4 -d /path/to/project
 ```
 
+While the agent is executing tasks, you can continue typing new requests.
+These messages are queued and the active plan is updated on the fly—no need
+to cancel the current run.
+
 ### Headless Mode
 
 Process a single prompt and exit (useful for scripting and automation):

--- a/src/agent/h1dr4-agent.ts
+++ b/src/agent/h1dr4-agent.ts
@@ -57,6 +57,7 @@ export class H1dr4Agent extends EventEmitter {
   private chatHistory: ChatEntry[] = [];
   private messages: H1dr4Message[] = [];
   private messageQueue: string[] = [];
+  private initialSystemMessage: H1dr4Message;
   private tokenCounter: TokenCounter;
   private abortController: AbortController | null = null;
   private mcpInitialized: boolean = false;
@@ -182,6 +183,7 @@ IMPORTANT RESPONSE GUIDELINES:
 
 Current working directory: ${process.cwd()}`,
     });
+    this.initialSystemMessage = this.messages[0];
   }
 
   private async initializeMCP(): Promise<void> {
@@ -890,6 +892,13 @@ Current working directory: ${process.cwd()}`,
     // Update token counter for new model
     this.tokenCounter.dispose();
     this.tokenCounter = createTokenCounter(model);
+  }
+
+  resetConversation(): void {
+    this.chatHistory = [];
+    this.messages = [this.initialSystemMessage];
+    this.messageQueue = [];
+    this.planManager.reset();
   }
 
   abortCurrentOperation(): void {

--- a/src/agent/h1dr4-agent.ts
+++ b/src/agent/h1dr4-agent.ts
@@ -708,34 +708,10 @@ Current working directory: ${process.cwd()}`,
           return await this.bash.execute(args.command);
 
         case "create_todo_list":
-          // Run todo list creation in the background
-          this.todoTool.createTodoList(args.todos).then((result) => {
-            if (!result.success) {
-              const entry: ChatEntry = {
-                type: "assistant",
-                content: result.error || "Error occurred",
-                timestamp: new Date(),
-              };
-              this.addChatEntry(entry);
-              this.messages.push({ role: "assistant", content: entry.content });
-            }
-          });
-          return { success: true, output: "Planning started (async)" };
+          return await this.todoTool.createTodoList(args.todos);
 
         case "update_todo_list":
-          // Run todo list updates in the background
-          this.todoTool.updateTodoList(args.updates).then((result) => {
-            if (!result.success) {
-              const entry: ChatEntry = {
-                type: "assistant",
-                content: result.error || "Error occurred",
-                timestamp: new Date(),
-              };
-              this.addChatEntry(entry);
-              this.messages.push({ role: "assistant", content: entry.content });
-            }
-          });
-          return { success: true, output: "Todo list update started (async)" };
+          return await this.todoTool.updateTodoList(args.updates);
 
         case "search":
           return await this.search.search(args.query, {

--- a/src/agent/plan-manager.ts
+++ b/src/agent/plan-manager.ts
@@ -41,4 +41,9 @@ export class PlanManager extends EventEmitter {
     this.todos.push(newTodo);
     await this.todoTool.createTodoList([newTodo]);
   }
+
+  reset(): void {
+    this.todos = [];
+    this.todoTool.resetTodoList();
+  }
 }

--- a/src/agent/plan-manager.ts
+++ b/src/agent/plan-manager.ts
@@ -1,0 +1,44 @@
+import { EventEmitter } from 'events';
+import { TodoTool } from '../tools';
+import { randomUUID } from 'crypto';
+
+interface TodoItem {
+  id: string;
+  content: string;
+  status: 'pending' | 'in_progress' | 'completed';
+  priority: 'high' | 'medium' | 'low';
+}
+
+export class PlanManager extends EventEmitter {
+  private todos: TodoItem[] = [];
+  constructor(private todoTool: TodoTool) {
+    super();
+    this.todoTool.on('todo_update', async () => {
+      const view = await this.todoTool.viewTodoList();
+      if (view.success && view.output) {
+        this.emit('plan_update', view.output);
+      }
+    });
+  }
+
+  async updateFromMessage(message: string): Promise<void> {
+    const lower = message.toLowerCase();
+    if (lower.includes('complete') || lower.includes('done')) {
+      const todo = this.todos.find((t) => t.status !== 'completed');
+      if (todo) {
+        todo.status = 'completed';
+        await this.todoTool.updateTodoList([{ id: todo.id, status: 'completed' }]);
+      }
+      return;
+    }
+
+    const newTodo: TodoItem = {
+      id: randomUUID(),
+      content: message,
+      status: 'pending',
+      priority: 'medium',
+    };
+    this.todos.push(newTodo);
+    await this.todoTool.createTodoList([newTodo]);
+  }
+}

--- a/src/hooks/use-input-handler.ts
+++ b/src/hooks/use-input-handler.ts
@@ -257,6 +257,9 @@ export function useInputHandler({
       setProcessingTime(0);
       processingStartTime.current = 0;
 
+      // Reset agent conversation and plan
+      agent.resetConversation();
+
       // Reset confirmation service session flags
       const confirmationService = ConfirmationService.getInstance();
       confirmationService.resetSession();

--- a/src/hooks/use-input-handler.ts
+++ b/src/hooks/use-input-handler.ts
@@ -179,6 +179,17 @@ export function useInputHandler({
     if (userInput.trim()) {
       const directCommandResult = await handleDirectCommand(userInput);
       if (!directCommandResult) {
+        if (isProcessing || isStreaming) {
+          const queuedEntry: ChatEntry = {
+            type: "user",
+            content: userInput,
+            timestamp: new Date(),
+          };
+          setChatHistory((prev) => [...prev, queuedEntry]);
+          agent.enqueueMessage(userInput);
+          clearInput();
+          return;
+        }
         await processUserMessage(userInput);
       }
     }

--- a/src/tools/todo-tool.ts
+++ b/src/tools/todo-tool.ts
@@ -171,6 +171,11 @@ export class TodoTool extends EventEmitter {
     }
   }
 
+  resetTodoList(): void {
+    this.todos = [];
+    this.emit('todo_update', this.formatTodoList());
+  }
+
   async viewTodoList(): Promise<ToolResult> {
     return {
       success: true,


### PR DESCRIPTION
## Summary
- queue user messages during streamed runs and route them to a new PlanManager
- PlanManager maintains todo state and emits `plan_update` events for UI refreshes
- allow UI to enqueue messages while agent works and document live plan updates in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a8d51ece34832cbdb5ff6d4e72deeb