### PR TITLE
feat: extend polymarket trading suite

### DIFF
--- a/src/agent/h1dr4-agent.ts
+++ b/src/agent/h1dr4-agent.ts
@@ -16,6 +16,7 @@ import {
   SearchTool,
   OSINTTool,
   ReasoningWorker,
+  PolymarketTool,
 } from "../tools";
 import { ToolResult } from "../types";
 import { EventEmitter } from "events";
@@ -52,6 +53,7 @@ export class H1dr4Agent extends EventEmitter {
   private search: SearchTool;
   private osint: OSINTTool;
   private reasoningWorker: ReasoningWorker;
+  private polymarket: PolymarketTool;
   private chatHistory: ChatEntry[] = [];
   private messages: H1dr4Message[] = [];
   private tokenCounter: TokenCounter;
@@ -89,6 +91,7 @@ export class H1dr4Agent extends EventEmitter {
     this.search = new SearchTool();
     this.osint = new OSINTTool();
     this.reasoningWorker = new ReasoningWorker();
+    this.polymarket = new PolymarketTool();
     this.tokenCounter = createTokenCounter(modelToUse);
 
     // Initialize MCP servers if configured
@@ -120,6 +123,20 @@ You have access to these tools:
 - osint_search: Perform OSINT leak retrieval for defined entities like email addresses, phone numbers, usernames, or domains
 - live_search: Search real-time web, news, and X posts using Grok's live search
 - reason: Use a dedicated reasoning model for predictions, market or geopolitical analysis, strategic planning, and other complex questions
+- polymarket: Access Polymarket markets, positions and execute trades
+
+POLYMARKET STRATEGY SUITE:
+ 1. Cross-market arbitrage – exploit price discrepancies across equivalent markets
+ 2. LP to market pools – capture fees in wide-spread markets with delta-neutral liquidity
+ 3. Bayesian updating vs market lag – act on new information faster than prices adjust
+ 4. Trade the oracle – anticipate resolution source behavior and biases
+ 5. Reflexivity farming – take positions that incentivize actions shaping outcomes
+ 6. Use odds to trade perps – convert prediction odds into signals for other assets
+ 7. Front-run attention for token plays – spot narrative momentum early via market activity
+ 8. Synthetic options – treat markets like options to trade volatility and time decay
+ 9. Construct your own parlay – combine markets for targeted exposure or hedging
+ 10. Tax harvesting – realize losses for regulatory advantages where applicable
+ 11. Trade infrastructure tokens – leverage platform health metrics for token positioning
 
 REASONING WORKER BEST PRACTICES:
  - Best for: Market analysis, geopolitical intelligence, predictive analysis, strategic planning, Monte Carlo simulations, or complex synthesis of multiple news sources
@@ -783,6 +800,9 @@ Current working directory: ${process.cwd()}`,
           ]);
 
           return reasoningResult;
+
+        case "polymarket":
+          return await this.polymarket.execute(args.action, args);
 
         default:
           // Check if this is an MCP tool

--- a/src/commands/polymarket.ts
+++ b/src/commands/polymarket.ts
@@ -1,0 +1,146 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { PolymarketAPI, OrderRequest } from '../polymarket/api';
+import { PolymarketStrategy } from '../polymarket/strategies';
+import { FundManager } from '../polymarket/fund';
+
+export function createPolymarketCommand(): Command {
+  const api = new PolymarketAPI();
+  const strategy = new PolymarketStrategy(api);
+  const fund = new FundManager();
+  const cmd = new Command('polymarket');
+  cmd.description('Interact with Polymarket markets and trading');
+
+  cmd
+    .command('markets')
+    .description('List active markets')
+    .option('-l, --liquidity <num>', 'minimum liquidity', '1000')
+    .action(async (opts) => {
+      try {
+        const markets = await api.getMarkets({
+          active: true,
+          liquidity_num_min: Number(opts.liquidity),
+          order: 'volume',
+          ascending: false,
+        });
+        console.log(JSON.stringify(markets, null, 2));
+      } catch (err: any) {
+        console.error(chalk.red(`Error fetching markets: ${err.message}`));
+      }
+    });
+
+  cmd
+    .command('positions <user>')
+    .description('Get positions for user address')
+    .action(async (user: string) => {
+      try {
+        const positions = await api.getPositions(user);
+        console.log(JSON.stringify(positions, null, 2));
+      } catch (err: any) {
+        console.error(chalk.red(`Error fetching positions: ${err.message}`));
+      }
+    });
+
+  cmd
+    .command('value <user>')
+    .description('Get portfolio value for user')
+    .option('-m, --market <id>', 'market id')
+    .action(async (user: string, opts) => {
+      try {
+        const value = await api.getPortfolioValue(user, opts.market);
+        console.log(JSON.stringify(value, null, 2));
+      } catch (err: any) {
+        console.error(chalk.red(`Error fetching value: ${err.message}`));
+      }
+    });
+
+  cmd
+    .command('trade')
+    .description('Place an order on Polymarket')
+    .requiredOption('-m, --market <id>', 'market id')
+    .requiredOption('-o, --outcome <id>', 'outcome id')
+    .requiredOption('-s, --side <side>', 'buy or sell')
+    .requiredOption('-z, --size <number>', 'size')
+    .requiredOption('-p, --price <number>', 'price')
+    .action(async (opts) => {
+      try {
+        const order: OrderRequest = {
+          market: opts.market,
+          outcome: opts.outcome,
+          side: opts.side,
+          size: Number(opts.size),
+          price: Number(opts.price),
+        };
+        fund.allocate(order.size * order.price);
+        const result = await api.placeOrder(order);
+        console.log(JSON.stringify(result, null, 2));
+      } catch (err: any) {
+        console.error(chalk.red(`Error placing order: ${err.message}`));
+      }
+    });
+
+  cmd
+    .command('arbitrage')
+    .description('Find cross-market arbitrage opportunities')
+    .option('-l, --liquidity <num>', 'minimum liquidity', '1000')
+    .option('-t, --threshold <num>', 'spread threshold', '0.05')
+    .action(async (opts) => {
+      try {
+        const opps = await strategy.findCrossMarketArbitrage(
+          Number(opts.liquidity),
+          Number(opts.threshold)
+        );
+        console.log(JSON.stringify(opps, null, 2));
+      } catch (err: any) {
+        console.error(chalk.red(`Error finding arbitrage: ${err.message}`));
+      }
+    });
+
+  cmd
+    .command('strategies')
+    .description('List available strategy modules')
+    .action(() => {
+      console.log(JSON.stringify(strategy.listStrategies(), null, 2));
+    });
+
+  cmd
+    .command('detect <name>')
+    .description('Run opportunity detection for a strategy')
+    .option('-l, --liquidity <num>', 'minimum liquidity', '1000')
+    .option('-t, --threshold <num>', 'spread or edge threshold', '0.05')
+    .option('-u, --user <address>', 'user address for position-based scans')
+    .action(async (name: string, opts) => {
+      try {
+        const res = await strategy.detect(name, {
+          minLiquidity: Number(opts.liquidity),
+          threshold: Number(opts.threshold),
+          user: opts.user,
+        });
+        console.log(JSON.stringify(res, null, 2));
+      } catch (err: any) {
+        console.error(chalk.red(`Detection failed: ${err.message}`));
+      }
+    });
+
+  const fundCmd = cmd.command('fund').description('Manage trading capital');
+  fundCmd
+    .command('status')
+    .description('View available capital')
+    .action(() => {
+      console.log(JSON.stringify({ capital: fund.getCapital() }, null, 2));
+    });
+
+  fundCmd
+    .command('deposit <amount>')
+    .description('Add capital to the fund')
+    .action((amount: string) => {
+      try {
+        fund.deposit(Number(amount));
+        console.log(JSON.stringify({ capital: fund.getCapital() }, null, 2));
+      } catch (err: any) {
+        console.error(chalk.red(`Deposit failed: ${err.message}`));
+      }
+    });
+
+  return cmd;
+}

--- a/src/h1dr4/tools.ts
+++ b/src/h1dr4/tools.ts
@@ -310,6 +310,48 @@ const BASE_H1DR4_TOOLS: H1dr4Tool[] = [
       },
     },
   },
+  {
+    type: "function",
+    function: {
+      name: "polymarket",
+      description:
+        "Interact with Polymarket APIs for market data, positions and trading",
+      parameters: {
+        type: "object",
+        properties: {
+          action: {
+            type: "string",
+            enum: [
+              "get_markets",
+              "get_positions",
+              "place_order",
+              "find_wide_spreads",
+            ],
+            description: "Type of operation to perform",
+          },
+          user: { type: "string", description: "User address for position queries" },
+          market: { type: "string", description: "Market identifier" },
+          outcome: { type: "string", description: "Outcome identifier" },
+          side: {
+            type: "string",
+            enum: ["buy", "sell"],
+            description: "Order side for trading",
+          },
+          size: { type: "number", description: "Token size for orders" },
+          price: { type: "number", description: "Price for orders" },
+          minLiquidity: {
+            type: "number",
+            description: "Minimum liquidity when searching spreads",
+          },
+          threshold: {
+            type: "number",
+            description: "Spread threshold when searching spreads",
+          },
+        },
+        required: ["action"],
+      },
+    },
+  },
 ];
 
 // Morph Fast Apply tool (conditional)

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { ConfirmationService } from "./utils/confirmation-service";
 import { createMCPCommand } from "./commands/mcp";
 import { createRSSCommand } from "./commands/rss";
 import { createScheduleCommand } from "./commands/schedule";
+import { createPolymarketCommand } from "./commands/polymarket";
 import { startAllTasks } from "./schedule/runner";
 import type { ChatCompletionMessageParam } from "openai/resources/chat";
 import fs from "fs";
@@ -472,5 +473,6 @@ gitCommand
 program.addCommand(createMCPCommand());
 program.addCommand(createRSSCommand());
 program.addCommand(createScheduleCommand());
+program.addCommand(createPolymarketCommand());
 
 program.parse();

--- a/src/polymarket/api.ts
+++ b/src/polymarket/api.ts
@@ -1,0 +1,55 @@
+import axios, { AxiosInstance } from 'axios';
+
+export interface MarketParams {
+  [key: string]: any;
+}
+
+export interface OrderRequest {
+  market: string;
+  outcome: string;
+  side: 'buy' | 'sell';
+  size: number;
+  price: number;
+}
+
+export class PolymarketAPI {
+  private gammaBase = 'https://gamma-api.polymarket.com';
+  private dataBase = 'https://data-api.polymarket.com';
+  private clobBase = 'https://clob.polymarket.com';
+  private client: AxiosInstance;
+  private apiKey?: string;
+
+  constructor(apiKey?: string) {
+    this.client = axios.create();
+    this.apiKey = apiKey || process.env.POLYMARKET_API_KEY;
+  }
+
+  async getMarkets(params: MarketParams = {}): Promise<any> {
+    const res = await this.client.get(`${this.gammaBase}/markets`, { params });
+    return res.data;
+  }
+
+  async getPositions(user: string, params: MarketParams = {}): Promise<any> {
+    const res = await this.client.get(`${this.dataBase}/positions`, {
+      params: { user, ...params },
+    });
+    return res.data;
+  }
+
+  async getPortfolioValue(user: string, market?: string): Promise<any> {
+    const res = await this.client.get(`${this.dataBase}/value`, {
+      params: { user, market },
+    });
+    return res.data;
+  }
+
+  async placeOrder(order: OrderRequest): Promise<any> {
+    if (!this.apiKey) {
+      throw new Error('POLYMARKET_API_KEY not set');
+    }
+    const res = await this.client.post(`${this.clobBase}/orders`, order, {
+      headers: { 'X-API-Key': this.apiKey },
+    });
+    return res.data;
+  }
+}

--- a/src/polymarket/fund.ts
+++ b/src/polymarket/fund.ts
@@ -1,0 +1,25 @@
+export class FundManager {
+  private capital: number;
+
+  constructor(initialCapital = 0) {
+    this.capital = initialCapital;
+  }
+
+  getCapital(): number {
+    return this.capital;
+  }
+
+  deposit(amount: number): void {
+    if (amount <= 0) throw new Error('Deposit must be positive');
+    this.capital += amount;
+  }
+
+  allocate(amount: number): void {
+    if (amount > this.capital) throw new Error('Insufficient capital');
+    this.capital -= amount;
+  }
+
+  recordProfit(amount: number): void {
+    this.capital += amount;
+  }
+}

--- a/src/polymarket/strategies.ts
+++ b/src/polymarket/strategies.ts
@@ -1,0 +1,314 @@
+import { PolymarketAPI } from './api';
+
+export interface StrategyInfo {
+  name: string;
+  description: string;
+}
+
+export class PolymarketStrategy {
+  constructor(private api: PolymarketAPI) {}
+
+  private strategyMap: Record<string, { description: string; detect?: (p: any) => Promise<any[]> }> = {
+    cross_market_arbitrage: {
+      description: 'Exploit price discrepancies for identical outcomes across markets.',
+      detect: async (p: any) =>
+        this.findCrossMarketArbitrage(p?.minLiquidity, p?.threshold),
+    },
+    lp_market_pools: {
+      description: 'Provide liquidity to wide-spread markets to capture fees delta-neutrally.',
+      detect: async (p: any) =>
+        this.findWideSpreads(p?.minLiquidity, p?.threshold),
+    },
+    bayesian_market_lag: {
+      description: 'Process new information faster than markets react and trade the delay.',
+      detect: async (p: any) => this.findBayesianLag(p?.threshold),
+    },
+    trade_the_oracle: {
+      description: 'Anticipate resolution source behavior and biases.',
+      detect: async (p: any) => this.findOracleBias(p?.minLiquidity),
+    },
+    reflexivity_farming: {
+      description: 'Take positions that incentivize actions shaping the outcome.',
+      detect: async (p: any) => this.findReflexiveMarkets(p?.minLiquidity),
+    },
+    odds_to_perps: {
+      description: 'Translate prediction odds into signals for perpetual or spot markets.',
+      detect: async (p: any) => this.findTokenSignals(p?.minLiquidity),
+    },
+    attention_front_run: {
+      description: 'Spot narrative momentum via new market activity and volume spikes.',
+      detect: async (p: any) =>
+        this.findAttentionSpikes(p?.minLiquidity, p?.threshold),
+    },
+    synthetic_options: {
+      description: 'Treat markets as options to trade volatility and time decay.',
+      detect: async (p: any) =>
+        this.findThetaMarkets(p?.minLiquidity, p?.threshold),
+    },
+    construct_parlay: {
+      description: 'Layer multiple markets for targeted exposure or hedging.',
+      detect: async (p: any) =>
+        this.findParlayMismatches(p?.minLiquidity, p?.threshold),
+    },
+    tax_harvest: {
+      description: 'Realize prediction market losses for regulatory advantages where applicable.',
+      detect: async (p: any) =>
+        this.findTaxLossPositions(p?.user, p?.threshold),
+    },
+    infrastructure_tokens: {
+      description: 'Use platform health metrics to time positions in native tokens.',
+      detect: async () => this.analyzeInfrastructure(),
+    },
+  };
+
+  listStrategies(): StrategyInfo[] {
+    return Object.entries(this.strategyMap).map(([name, { description }]) => ({
+      name,
+      description,
+    }));
+  }
+
+  async detect(name: string, params: any = {}): Promise<any[]> {
+    const strat = this.strategyMap[name];
+    if (!strat) {
+      throw new Error(`Unknown strategy: ${name}`);
+    }
+    if (!strat.detect) {
+      return [];
+    }
+    return strat.detect(params);
+  }
+
+  /**
+   * Find markets with spreads wider than threshold
+   */
+  async findWideSpreads(minLiquidity = 1000, spreadThreshold = 0.05): Promise<any[]> {
+    const markets = await this.api.getMarkets({
+      active: true,
+      liquidity_num_min: minLiquidity,
+      order: 'volume',
+      ascending: false,
+    });
+
+    const opportunities: any[] = [];
+    for (const m of markets) {
+      const bestBid = m.bestBid ?? 0;
+      const bestAsk = m.bestAsk ?? 0;
+      const spread = bestAsk - bestBid;
+      if (bestBid && bestAsk && spread > spreadThreshold) {
+        opportunities.push({ id: m.id, slug: m.slug, bestBid, bestAsk, spread });
+      }
+    }
+    return opportunities;
+  }
+
+  /**
+   * Identify cross-market arbitrage opportunities by comparing prices of
+   * markets with identical slugs. This is a lightweight implementation that
+   * groups active markets by slug and flags any groups where the price spread
+   * between outcomes exceeds the specified threshold.
+   */
+  async findCrossMarketArbitrage(
+    minLiquidity = 1000,
+    spreadThreshold = 0.05
+  ): Promise<any[]> {
+    const markets = await this.api.getMarkets({
+      active: true,
+      liquidity_num_min: minLiquidity,
+    });
+
+    const groups: Record<string, any[]> = {};
+    for (const m of markets) {
+      if (!groups[m.slug]) groups[m.slug] = [];
+      groups[m.slug].push(m);
+    }
+
+    const opportunities: any[] = [];
+    for (const slug of Object.keys(groups)) {
+      const group = groups[slug];
+      if (group.length < 2) continue;
+      const prices = group.map((g) => g.yesPrice ?? g.lastPrice ?? 0);
+      const max = Math.max(...prices);
+      const min = Math.min(...prices);
+      if (max - min > spreadThreshold) {
+        opportunities.push({ slug, max, min, spread: max - min });
+      }
+    }
+    return opportunities;
+  }
+
+  /**
+   * Markets with stale trading activity may indicate a lag between new
+   * information and market pricing. This heuristic flags markets whose last
+   * trade timestamp exceeds the supplied hour threshold.
+   */
+  async findBayesianLag(maxHours = 24): Promise<any[]> {
+    const markets = await this.api.getMarkets({ active: true });
+    const thresholdMs = maxHours * 60 * 60 * 1000;
+    const now = Date.now();
+    const stale: any[] = [];
+    for (const m of markets) {
+      const last = Date.parse(m.lastTradeTime || m.last_trade_time || m.updated || '');
+      if (last && now - last > thresholdMs) {
+        stale.push({ id: m.id, slug: m.slug, lastTrade: m.lastTradeTime || m.last_trade_time || m.updated });
+      }
+    }
+    return stale;
+  }
+
+  /**
+   * Identify markets whose resolution source may introduce oracle bias. Here we
+   * simply surface markets with explicit resolutionSource metadata so that
+   * humans can evaluate potential subjectivity.
+   */
+  async findOracleBias(minLiquidity = 0): Promise<any[]> {
+    const markets = await this.api.getMarkets({ active: true, liquidity_num_min: minLiquidity });
+    return markets
+      .filter((m: any) => typeof m.resolutionSource === 'string')
+      .map((m: any) => ({ id: m.id, slug: m.slug, resolutionSource: m.resolutionSource }));
+  }
+
+  /**
+   * Detect markets where participant actions can influence outcomes. We use a
+   * keyword filter as a lightweight proxy for reflexive incentives.
+   */
+  async findReflexiveMarkets(minLiquidity = 0): Promise<any[]> {
+    const markets = await this.api.getMarkets({ active: true, liquidity_num_min: minLiquidity });
+    const keywords = ['launch', 'release', 'deploy', 'mint', 'vote', 'upgrade'];
+    const reflexive: any[] = [];
+    for (const m of markets) {
+      const title = (m.title || '').toLowerCase();
+      if (keywords.some((k) => title.includes(k))) {
+        reflexive.push({ id: m.id, slug: m.slug, title: m.title });
+      }
+    }
+    return reflexive;
+  }
+
+  /**
+   * Use prediction odds as directional signals for tokens or perps. We surface
+   * markets mentioning price or token keywords along with their current odds.
+   */
+  async findTokenSignals(minLiquidity = 0): Promise<any[]> {
+    const markets = await this.api.getMarkets({ active: true, liquidity_num_min: minLiquidity });
+    const keywords = ['price', 'token', 'coin', 'market cap'];
+    const signals: any[] = [];
+    for (const m of markets) {
+      const title = (m.title || '').toLowerCase();
+      if (keywords.some((k) => title.includes(k))) {
+        const price = m.yesPrice ?? m.lastPrice ?? 0;
+        signals.push({ id: m.id, slug: m.slug, price });
+      }
+    }
+    return signals;
+  }
+
+  /**
+   * Identify newly created markets attracting outsized volume, a proxy for
+   * emerging narratives and attention flows.
+   */
+  async findAttentionSpikes(minLiquidity = 0, volumeThreshold = 10000): Promise<any[]> {
+    const markets = await this.api.getMarkets({
+      active: true,
+      liquidity_num_min: minLiquidity,
+      order: 'volume',
+      ascending: false,
+    });
+    const now = Date.now();
+    const recentMs = 3 * 24 * 60 * 60 * 1000; // 3 days
+    const spikes: any[] = [];
+    for (const m of markets) {
+      const start = Date.parse(m.start_date || m.created || '');
+      if (start && now - start < recentMs && (m.volume || 0) > volumeThreshold) {
+        spikes.push({ id: m.id, slug: m.slug, volume: m.volume });
+      }
+    }
+    return spikes;
+  }
+
+  /**
+   * Markets nearing resolution with balanced odds behave like options with high
+   * theta. We flag markets ending soon whose prices remain near 50%.
+   */
+  async findThetaMarkets(minLiquidity = 0, days = 7): Promise<any[]> {
+    const markets = await this.api.getMarkets({ active: true, liquidity_num_min: minLiquidity });
+    const now = Date.now();
+    const windowMs = days * 24 * 60 * 60 * 1000;
+    const theta: any[] = [];
+    for (const m of markets) {
+      const end = Date.parse(m.end_date || m.endDate || '');
+      const price = m.yesPrice ?? m.lastPrice ?? 0;
+      if (end && end - now < windowMs && price > 0.3 && price < 0.7) {
+        theta.push({ id: m.id, slug: m.slug, price, endDate: m.end_date || m.endDate });
+      }
+    }
+    return theta;
+  }
+
+  /**
+   * Sum outcome probabilities within each event to surface mispricings that can
+   * be combined into synthetic parlays.
+   */
+  async findParlayMismatches(minLiquidity = 0, threshold = 0.05): Promise<any[]> {
+    const markets = await this.api.getMarkets({ active: true, liquidity_num_min: minLiquidity });
+    const groups: Record<string, any[]> = {};
+    for (const m of markets) {
+      const event = m.event_id || m.eventId || m.eventSlug;
+      if (!event) continue;
+      if (!groups[event]) groups[event] = [];
+      groups[event].push(m);
+    }
+    const opps: any[] = [];
+    for (const event of Object.keys(groups)) {
+      const group = groups[event];
+      if (group.length < 2) continue;
+      const sum = group.reduce((s, g) => s + (g.yesPrice ?? g.lastPrice ?? 0), 0);
+      if (sum < 1 - threshold || sum > 1 + threshold) {
+        opps.push({
+          event,
+          probabilitySum: sum,
+          markets: group.map((g) => ({ id: g.id, slug: g.slug, price: g.yesPrice ?? g.lastPrice ?? 0 })),
+        });
+      }
+    }
+    return opps;
+  }
+
+  /**
+   * Surface user positions with significant unrealized losses that could be
+   * harvested for tax purposes. Requires a user address parameter.
+   */
+  async findTaxLossPositions(user?: string, pnlThreshold = -0.1): Promise<any[]> {
+    if (!user) return [];
+    const positions = await this.api.getPositions(user, { sizeThreshold: 1 });
+    return positions
+      .filter((p: any) => typeof p.percentPnl === 'number' && p.percentPnl < pnlThreshold)
+      .map((p: any) => ({ market: p.market, percentPnl: p.percentPnl, size: p.size }));
+  }
+
+  /**
+   * Aggregate platform-wide metrics as a proxy for infrastructure token value.
+   */
+  async analyzeInfrastructure(): Promise<any[]> {
+    const markets = await this.api.getMarkets({ active: true });
+    const totalVolume = markets.reduce((sum: number, m: any) => sum + (m.volume || 0), 0);
+    return [{ totalVolume, activeMarkets: markets.length }];
+  }
+
+  /**
+   * Basic Kelly position sizing implementation. The profitMargin represents the
+   * expected percentage profit (e.g. 0.05 for 5%), executionProbability is the
+   * probability both legs of the trade execute successfully. The returned
+   * number is the fraction of total capital to allocate.
+   */
+  calculateKellyPositionSize(
+    profitMargin: number,
+    executionProbability: number,
+    maxFraction = 0.25
+  ): number {
+    const q = 1 - executionProbability;
+    const b = profitMargin;
+    const kelly = (executionProbability * b - q) / b;
+    return Math.max(0, Math.min(kelly * maxFraction, maxFraction));
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,3 +6,4 @@ export { ConfirmationTool } from "./confirmation-tool";
 export { SearchTool } from "./search";
 export { OSINTTool } from "./osint";
 export { ReasoningWorker } from "./reasoning-worker";
+export { PolymarketTool } from "./polymarket";

--- a/src/tools/polymarket.ts
+++ b/src/tools/polymarket.ts
@@ -1,0 +1,72 @@
+import { ToolResult } from '../types';
+import { PolymarketAPI, OrderRequest } from '../polymarket/api';
+import { PolymarketStrategy } from '../polymarket/strategies';
+import { FundManager } from '../polymarket/fund';
+
+export class PolymarketTool {
+  private api: PolymarketAPI;
+  private strategy: PolymarketStrategy;
+  private fund: FundManager;
+
+  constructor() {
+    this.api = new PolymarketAPI();
+    this.strategy = new PolymarketStrategy(this.api);
+    this.fund = new FundManager();
+  }
+
+  async execute(action: string, params: any = {}): Promise<ToolResult> {
+    try {
+        switch (action) {
+          case 'get_markets': {
+            const markets = await this.api.getMarkets(params);
+            return { success: true, output: JSON.stringify(markets, null, 2), data: markets };
+          }
+        case 'get_positions': {
+          const positions = await this.api.getPositions(params.user, params);
+          return { success: true, output: JSON.stringify(positions, null, 2), data: positions };
+        }
+        case 'get_value': {
+          const value = await this.api.getPortfolioValue(params.user, params.market);
+          return { success: true, output: JSON.stringify(value, null, 2), data: value };
+        }
+        case 'place_order': {
+          const order = params as OrderRequest;
+          const result = await this.api.placeOrder(order);
+          return { success: true, output: JSON.stringify(result, null, 2), data: result };
+        }
+        case 'find_wide_spreads': {
+          const spreads = await this.strategy.findWideSpreads(params.minLiquidity, params.threshold);
+          return { success: true, output: JSON.stringify(spreads, null, 2), data: spreads };
+        }
+        case 'find_arbitrage': {
+          const opps = await this.strategy.findCrossMarketArbitrage(params.minLiquidity, params.threshold);
+          return { success: true, output: JSON.stringify(opps, null, 2), data: opps };
+        }
+        case 'kelly_size': {
+          const fraction = this.strategy.calculateKellyPositionSize(params.profitMargin, params.executionProbability, params.maxFraction);
+          return { success: true, output: JSON.stringify({ fraction }, null, 2), data: { fraction } };
+        }
+        case 'fund_status': {
+          const capital = this.fund.getCapital();
+          return { success: true, output: JSON.stringify({ capital }, null, 2), data: { capital } };
+        }
+          case 'fund_deposit': {
+            this.fund.deposit(params.amount);
+            return { success: true, output: JSON.stringify({ capital: this.fund.getCapital() }, null, 2), data: { capital: this.fund.getCapital() } };
+          }
+          case 'list_strategies': {
+            const list = this.strategy.listStrategies();
+            return { success: true, output: JSON.stringify(list, null, 2), data: list };
+          }
+          case 'detect': {
+            const opps = await this.strategy.detect(params.strategy, params);
+            return { success: true, output: JSON.stringify(opps, null, 2), data: opps };
+          }
+          default:
+            return { success: false, error: `Unknown action: ${action}` };
+        }
+    } catch (err: any) {
+      return { success: false, error: `Polymarket error: ${err.message}` };
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- enable detection hooks for all eleven Polymarket strategies so the agent can scan any ethos-defined play
- add heuristic detectors for token signals, attention spikes, parlay mispricings, tax-loss positions, and platform health
- allow CLI strategy detection to accept a user address for position-based scans

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0f307ee34832c83e99f441af240d4