### PR TITLE
feat(schedule): add watch mode for event tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,13 @@ h1dr4 schedule remove TASK_ID
 ```
 
 Scheduled tasks run even if the CLI is closed. A background daemon watches
-`~/.h1dr4/schedules.json` and launches the command at the specified time. Watch tasks check for new items from the requested tickers, keywords, or sources and only alert when the analyzed impact meets your chosen threshold. When a source is provided, the watcher polls public RSS feeds for those accounts and flags any posts containing 0x‑style contract addresses. Deduplication ensures previously seen items are skipped. If the chat interface is open, output is printed directly in the terminal. Otherwise, the daemon attempts to open a new terminal window to execute the command.
+`~/.h1dr4/schedules.json` and launches the command at the specified time. Watch
+tasks build live search queries from the requested tickers, keywords, or
+sources and only alert when the analyzed impact meets your chosen threshold.
+Each run deduplicates previously seen results and flags posts containing
+0x‑style contract addresses. If the chat interface is open, output is printed
+directly in the terminal. Otherwise, the daemon attempts to open a new terminal
+window to execute the command.
 
 ### Managing MCP Servers
 

--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ h1dr4 rss remove myfeed
 h1dr4 schedule add "0 9 * * 1" "echo 'weekly task'"
 
 # Schedule a watch-based alert
-h1dr4 schedule watch "*/5 * * * *" -t BTC -k "Fed policy" --threshold Mid-High
+h1dr4 schedule watch "*/5 * * * *" -t BTC -k "Fed policy" -s trump --threshold Mid-High
 
 # List scheduled tasks
 h1dr4 schedule list
@@ -460,9 +460,7 @@ h1dr4 schedule remove TASK_ID
 ```
 
 Scheduled tasks run even if the CLI is closed. A background daemon watches
-`~/.h1dr4/schedules.json` and launches the command at the specified time. Watch tasks check for new items and only alert when the impact meets your chosen threshold. If the
-chat interface is open, output is printed directly in the terminal. Otherwise,
-the daemon attempts to open a new terminal window to execute the command.
+`~/.h1dr4/schedules.json` and launches the command at the specified time. Watch tasks check for new items from the requested tickers, keywords, or sources and only alert when the analyzed impact meets your chosen threshold. Deduplication ensures previously seen items are skipped. If the chat interface is open, output is printed directly in the terminal. Otherwise, the daemon attempts to open a new terminal window to execute the command.
 
 ### Managing MCP Servers
 

--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ h1dr4 rss remove myfeed
 h1dr4 schedule add "0 9 * * 1" "echo 'weekly task'"
 
 # Schedule a watch-based alert
-h1dr4 schedule watch "*/5 * * * *" -t BTC -k "Fed policy" -s trump --threshold Mid-High
+h1dr4 schedule watch "*/5 * * * *" -t BTC -k "Fed policy" -s trump -c "policy news that could move BTC" --threshold Mid-High
 
 # List scheduled tasks
 h1dr4 schedule list
@@ -465,11 +465,10 @@ Scheduled tasks run even if the CLI is closed. A background daemon watches
 Watch tasks execute a full H1DR4 query using all available tools (search,
 RSS, reasoning, etc.). Each interval retrieves only new items for the
 requested tickers, keywords, or sources. Results are deduplicated, evaluated
-against the configured impact threshold, and alerts are emitted only when the
-analysis meets or exceeds that level. The watcher also flags any 0x‑style
-contract addresses it discovers. If the chat interface is open, output is
-printed directly in the terminal; otherwise, the daemon attempts to open a new
-terminal window to display the alert.
+against your provided criteria and impact threshold, and alerts are emitted
+only when the analysis meets or exceeds that level. If the chat interface is
+open, output is printed directly in the terminal; otherwise, the daemon
+attempts to open a new terminal window to display the alert.
 
 ### Managing MCP Servers
 

--- a/README.md
+++ b/README.md
@@ -460,13 +460,16 @@ h1dr4 schedule remove TASK_ID
 ```
 
 Scheduled tasks run even if the CLI is closed. A background daemon watches
-`~/.h1dr4/schedules.json` and launches the command at the specified time. Watch
-tasks build live search queries from the requested tickers, keywords, or
-sources and only alert when the analyzed impact meets your chosen threshold.
-Each run deduplicates previously seen results and flags posts containing
-0x‑style contract addresses. If the chat interface is open, output is printed
-directly in the terminal. Otherwise, the daemon attempts to open a new terminal
-window to execute the command.
+`~/.h1dr4/schedules.json` and launches the command at the specified time.
+
+Watch tasks execute a full H1DR4 query using all available tools (search,
+RSS, reasoning, etc.). Each interval retrieves only new items for the
+requested tickers, keywords, or sources. Results are deduplicated, evaluated
+against the configured impact threshold, and alerts are emitted only when the
+analysis meets or exceeds that level. The watcher also flags any 0x‑style
+contract addresses it discovers. If the chat interface is open, output is
+printed directly in the terminal; otherwise, the daemon attempts to open a new
+terminal window to display the alert.
 
 ### Managing MCP Servers
 

--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ h1dr4 schedule remove TASK_ID
 ```
 
 Scheduled tasks run even if the CLI is closed. A background daemon watches
-`~/.h1dr4/schedules.json` and launches the command at the specified time. Watch tasks check for new items from the requested tickers, keywords, or sources and only alert when the analyzed impact meets your chosen threshold. Deduplication ensures previously seen items are skipped. If the chat interface is open, output is printed directly in the terminal. Otherwise, the daemon attempts to open a new terminal window to execute the command.
+`~/.h1dr4/schedules.json` and launches the command at the specified time. Watch tasks check for new items from the requested tickers, keywords, or sources and only alert when the analyzed impact meets your chosen threshold. When a source is provided, the watcher polls public RSS feeds for those accounts and flags any posts containing 0x‑style contract addresses. Deduplication ensures previously seen items are skipped. If the chat interface is open, output is printed directly in the terminal. Otherwise, the daemon attempts to open a new terminal window to execute the command.
 
 ### Managing MCP Servers
 

--- a/README.md
+++ b/README.md
@@ -449,6 +449,9 @@ h1dr4 rss remove myfeed
 # Schedule a command using cron syntax
 h1dr4 schedule add "0 9 * * 1" "echo 'weekly task'"
 
+# Schedule a watch-based alert
+h1dr4 schedule watch "*/5 * * * *" -t BTC -k "Fed policy" --threshold Mid-High
+
 # List scheduled tasks
 h1dr4 schedule list
 
@@ -457,7 +460,7 @@ h1dr4 schedule remove TASK_ID
 ```
 
 Scheduled tasks run even if the CLI is closed. A background daemon watches
-`~/.h1dr4/schedules.json` and launches the command at the specified time. If the
+`~/.h1dr4/schedules.json` and launches the command at the specified time. Watch tasks check for new items and only alert when the impact meets your chosen threshold. If the
 chat interface is open, output is printed directly in the terminal. Otherwise,
 the daemon attempts to open a new terminal window to execute the command.
 

--- a/src/agent/h1dr4-agent.ts
+++ b/src/agent/h1dr4-agent.ts
@@ -164,9 +164,9 @@ TASK PLANNING WITH TODO LISTS:
 
 SCHEDULING TASKS:
 - Schedule shell commands with \`h1dr4 schedule add "<cron>" "<command>"\`
-- Create watch-based alerts with \`h1dr4 schedule watch "<cron>" -t <tickers> -k <keywords> --threshold <Low|Mid-High|High>\`
-  - Ask for a cron interval, tickers or keywords to monitor, and an impact threshold (defaults to High)
-  - The scheduler checks for new items and triggers alerts only when the impact meets the threshold
+- Create watch-based alerts with \`h1dr4 schedule watch "<cron>" -t <tickers> -k <keywords> -s <sources> --threshold <Low|Mid-High|High>\`
+  - Ask for a cron interval, tickers/keywords/sources to monitor, and an impact threshold (defaults to High)
+  - The scheduler runs a full query using available tools (search, reasoning, RSS, etc.), deduplicates results, and only alerts when new items meet the threshold
 - Use \`h1dr4 schedule list\` to view existing tasks
 - Use \`h1dr4 schedule remove <id>\` to cancel a task; to modify one, remove it and add a new entry
 - Tasks are stored in \`~/.h1dr4/schedules.json\`, run automatically when due, and bypass confirmation

--- a/src/agent/h1dr4-agent.ts
+++ b/src/agent/h1dr4-agent.ts
@@ -164,9 +164,9 @@ TASK PLANNING WITH TODO LISTS:
 
 SCHEDULING TASKS:
 - Schedule shell commands with \`h1dr4 schedule add "<cron>" "<command>"\`
-- Create watch-based alerts with \`h1dr4 schedule watch "<cron>" -t <tickers> -k <keywords> -s <sources> --threshold <Low|Mid-High|High>\`
-  - Ask for a cron interval, tickers/keywords/sources to monitor, and an impact threshold (defaults to High)
-  - The scheduler runs a full query using available tools (search, reasoning, RSS, etc.), deduplicates results, and only alerts when new items meet the threshold
+- Create watch-based alerts with \`h1dr4 schedule watch "<cron>" -t <tickers> -k <keywords> -s <sources> -c <criteria> --threshold <Low|Mid-High|High>\`
+  - Ask for a cron interval, tickers/keywords/sources to monitor, evaluation criteria, and an impact threshold (defaults to High)
+  - The scheduler runs a full query using available tools (search, reasoning, RSS, etc.), deduplicates results, evaluates each item against the criteria, and only alerts when new items meet the threshold
 - Use \`h1dr4 schedule list\` to view existing tasks
 - Use \`h1dr4 schedule remove <id>\` to cancel a task; to modify one, remove it and add a new entry
 - Tasks are stored in \`~/.h1dr4/schedules.json\`, run automatically when due, and bypass confirmation

--- a/src/agent/h1dr4-agent.ts
+++ b/src/agent/h1dr4-agent.ts
@@ -164,6 +164,9 @@ TASK PLANNING WITH TODO LISTS:
 
 SCHEDULING TASKS:
 - Schedule shell commands with \`h1dr4 schedule add "<cron>" "<command>"\`
+- Create watch-based alerts with \`h1dr4 schedule watch "<cron>" -t <tickers> -k <keywords> --threshold <Low|Mid-High|High>\`
+  - Ask for a cron interval, tickers or keywords to monitor, and an impact threshold (defaults to High)
+  - The scheduler checks for new items and triggers alerts only when the impact meets the threshold
 - Use \`h1dr4 schedule list\` to view existing tasks
 - Use \`h1dr4 schedule remove <id>\` to cancel a task; to modify one, remove it and add a new entry
 - Tasks are stored in \`~/.h1dr4/schedules.json\`, run automatically when due, and bypass confirmation

--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -32,6 +32,7 @@ export function createScheduleCommand(): Command {
     .description("Schedule an event watchlist")
     .option("-t, --ticker <ticker...>", "Tickers to monitor")
     .option("-k, --keyword <keyword...>", "Keywords to monitor")
+    .option("-s, --source <source...>", "Sources or accounts to monitor")
     .option(
       "--threshold <level>",
       "Alert threshold (Low|Mid-High|High)",
@@ -43,12 +44,14 @@ export function createScheduleCommand(): Command {
         options: {
           ticker?: string[];
           keyword?: string[];
+          source?: string[];
           threshold: ImpactLevel;
         }
       ) => {
         const watch = {
           tickers: options.ticker,
           keywords: options.keyword,
+          sources: options.source,
           threshold: options.threshold,
         };
         const task = { id: randomUUID(), cron, watch };

--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -1,6 +1,11 @@
 import { Command } from "commander";
 import chalk from "chalk";
-import { addSchedule, loadSchedules, removeSchedule } from "../schedule/config";
+import {
+  addSchedule,
+  loadSchedules,
+  removeSchedule,
+  ImpactLevel,
+} from "../schedule/config";
 import { randomUUID } from "crypto";
 import { spawn } from "child_process";
 import fs from "fs";
@@ -23,6 +28,37 @@ export function createScheduleCommand(): Command {
     });
 
   scheduleCommand
+    .command("watch <cron>")
+    .description("Schedule an event watchlist")
+    .option("-t, --ticker <ticker...>", "Tickers to monitor")
+    .option("-k, --keyword <keyword...>", "Keywords to monitor")
+    .option(
+      "--threshold <level>",
+      "Alert threshold (Low|Mid-High|High)",
+      "High"
+    )
+    .action(
+      (
+        cron: string,
+        options: {
+          ticker?: string[];
+          keyword?: string[];
+          threshold: ImpactLevel;
+        }
+      ) => {
+        const watch = {
+          tickers: options.ticker,
+          keywords: options.keyword,
+          threshold: options.threshold,
+        };
+        const task = { id: randomUUID(), cron, watch };
+        addSchedule(task);
+        reloadSchedulers();
+        console.log(chalk.green(`✓ Scheduled watch ${task.id}`));
+      }
+    );
+
+  scheduleCommand
     .command("list")
     .description("List scheduled tasks")
     .action(() => {
@@ -32,7 +68,13 @@ export function createScheduleCommand(): Command {
         return;
       }
       console.log(chalk.bold("Scheduled tasks:"));
-      tasks.forEach((t) => console.log(`${t.id}: ${t.cron} -> ${t.command}`));
+      tasks.forEach((t) => {
+        if (t.watch) {
+          console.log(`${t.id}: ${t.cron} -> watch`);
+        } else if (t.command) {
+          console.log(`${t.id}: ${t.cron} -> ${t.command}`);
+        }
+      });
     });
 
   scheduleCommand

--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -33,6 +33,7 @@ export function createScheduleCommand(): Command {
     .option("-t, --ticker <ticker...>", "Tickers to monitor")
     .option("-k, --keyword <keyword...>", "Keywords to monitor")
     .option("-s, --source <source...>", "Sources or accounts to monitor")
+    .option("-c, --criteria <criteria>", "Evaluation criteria for alerts")
     .option(
       "--threshold <level>",
       "Alert threshold (Low|Mid-High|High)",
@@ -45,6 +46,7 @@ export function createScheduleCommand(): Command {
           ticker?: string[];
           keyword?: string[];
           source?: string[];
+          criteria?: string;
           threshold: ImpactLevel;
         }
       ) => {
@@ -52,6 +54,7 @@ export function createScheduleCommand(): Command {
           tickers: options.ticker,
           keywords: options.keyword,
           sources: options.source,
+          criteria: options.criteria,
           threshold: options.threshold,
         };
         const task = { id: randomUUID(), cron, watch };

--- a/src/schedule/config.ts
+++ b/src/schedule/config.ts
@@ -8,6 +8,7 @@ export interface WatchConfig {
   tickers?: string[];
   keywords?: string[];
   sources?: string[];
+  criteria?: string;
   threshold?: ImpactLevel;
 }
 

--- a/src/schedule/config.ts
+++ b/src/schedule/config.ts
@@ -2,10 +2,19 @@ import fs from "fs";
 import path from "path";
 import os from "os";
 
+export type ImpactLevel = "Low" | "Mid-High" | "High";
+
+export interface WatchConfig {
+  tickers?: string[];
+  keywords?: string[];
+  threshold?: ImpactLevel;
+}
+
 export interface ScheduledTask {
   id: string;
   cron: string;
-  command: string;
+  command?: string;
+  watch?: WatchConfig;
 }
 
 const CONFIG_FILE = path.join(os.homedir(), ".h1dr4", "schedules.json");

--- a/src/schedule/config.ts
+++ b/src/schedule/config.ts
@@ -7,6 +7,7 @@ export type ImpactLevel = "Low" | "Mid-High" | "High";
 export interface WatchConfig {
   tickers?: string[];
   keywords?: string[];
+  sources?: string[];
   threshold?: ImpactLevel;
 }
 

--- a/src/schedule/runner.ts
+++ b/src/schedule/runner.ts
@@ -5,6 +5,7 @@ import path from "path";
 import os from "os";
 import { loadSchedules, ScheduledTask } from "./config";
 import { ConfirmationService } from "../utils/confirmation-service";
+import { runWatchTask } from "./watch";
 
 const CONFIG_FILE = path.join(os.homedir(), ".h1dr4", "schedules.json");
 let watcher: fs.FSWatcher | null = null;
@@ -17,7 +18,9 @@ export function startAllTasks(): void {
   }
   jobs = {};
   for (const task of tasks) {
-    jobs[task.id] = schedule.scheduleJob(task.cron, () => runTask(task));
+    jobs[task.id] = schedule.scheduleJob(task.cron, () => {
+      void runTask(task);
+    });
   }
   if (!watcher) {
     const dir = path.dirname(CONFIG_FILE);
@@ -43,13 +46,19 @@ function spawnInTerminal(command: string): void {
   }
 }
 
-function runTask(task: ScheduledTask): void {
+async function runTask(task: ScheduledTask): Promise<void> {
   const confirmationService = ConfirmationService.getInstance();
   confirmationService.setSessionFlag("allOperations", true);
-  if (process.stdout.isTTY) {
-    spawn(task.command, { shell: true, stdio: "inherit" });
-  } else {
-    // no TTY, open in new terminal
-    spawnInTerminal(task.command);
+  if (task.watch) {
+    await runWatchTask(task);
+    return;
+  }
+  if (task.command) {
+    if (process.stdout.isTTY) {
+      spawn(task.command, { shell: true, stdio: "inherit" });
+    } else {
+      // no TTY, open in new terminal
+      spawnInTerminal(task.command);
+    }
   }
 }

--- a/src/schedule/state.ts
+++ b/src/schedule/state.ts
@@ -1,0 +1,22 @@
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+interface WatchState {
+  seenIds: string[];
+}
+
+const STATE_FILE = path.join(os.homedir(), ".h1dr4", "watch-state.json");
+
+export function loadWatchState(): Record<string, WatchState> {
+  try {
+    return JSON.parse(fs.readFileSync(STATE_FILE, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+export function saveWatchState(state: Record<string, WatchState>): void {
+  fs.mkdirSync(path.dirname(STATE_FILE), { recursive: true });
+  fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
+}

--- a/src/schedule/watch.ts
+++ b/src/schedule/watch.ts
@@ -1,4 +1,5 @@
 import chalk from "chalk";
+import Parser from "rss-parser";
 import { ScheduledTask, ImpactLevel } from "./config";
 import { loadWatchState, saveWatchState } from "./state";
 
@@ -14,28 +15,58 @@ function detectContractAddress(text: string): string | undefined {
 }
 
 async function fetchNewItems(task: ScheduledTask): Promise<WatchItem[]> {
-  // Placeholder for event detection logic integrating RSS, MCP, etc.
-  const keywords = task.watch?.keywords?.join(", ");
-  const tickers = task.watch?.tickers?.join(", ");
-  const sources = task.watch?.sources?.join(", ");
-  if (!keywords && !tickers && !sources) {
-    return [];
+  const parser = new Parser();
+  const items: WatchItem[] = [];
+
+  const keywords = task.watch?.keywords?.map((k) => k.toLowerCase());
+  const tickers = task.watch?.tickers?.map((t) => t.toLowerCase());
+  const sources = task.watch?.sources || [];
+
+  if (sources.length === 0) return items;
+
+  for (const rawSource of sources) {
+    const handle = rawSource.replace(/^@/, "");
+    const url = `https://nitter.net/${handle}/rss`;
+    try {
+      const feed = await parser.parseURL(url);
+      for (const entry of feed.items || []) {
+        const content = `${entry.title || ""} ${
+          entry.contentSnippet || ""
+        }`.trim();
+        const lower = content.toLowerCase();
+
+        const matchesKeyword = keywords
+          ? keywords.some((k) => lower.includes(k))
+          : false;
+        const matchesTicker = tickers
+          ? tickers.some((t) => lower.includes(t))
+          : false;
+        const contract = detectContractAddress(content);
+
+        if (keywords || tickers) {
+          if (!matchesKeyword && !matchesTicker && !contract) continue;
+        } else if (!contract) {
+          continue;
+        }
+
+        const meta: Record<string, string> = { source: rawSource };
+        if (entry.link) meta.link = entry.link;
+        if (contract) meta.contractAddress = contract;
+
+        items.push({
+          id: entry.id || entry.guid || entry.link || entry.pubDate || content,
+          summary: content || "New post",
+          metadata: meta,
+        });
+      }
+    } catch (error) {
+      console.warn(
+        `Failed to fetch source ${rawSource}: ${(error as Error).message}`
+      );
+    }
   }
-  const meta: Record<string, string> = {};
-  if (keywords) meta.keywords = keywords;
-  if (tickers) meta.tickers = tickers;
-  if (sources) meta.sources = sources;
-  // Simulate a detected summary
-  const summary = `Detected event for ${keywords || tickers || sources}`;
-  const contract = detectContractAddress(summary);
-  if (contract) meta.contractAddress = contract;
-  return [
-    {
-      id: Date.now().toString(),
-      summary,
-      metadata: meta,
-    },
-  ];
+
+  return items;
 }
 
 function analyzeImpact(item: WatchItem): ImpactLevel {

--- a/src/schedule/watch.ts
+++ b/src/schedule/watch.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import { H1dr4Client } from "../h1dr4/client";
+import { H1dr4Client, H1dr4Message } from "../h1dr4/client";
 import { ScheduledTask, ImpactLevel } from "./config";
 import { loadWatchState, saveWatchState } from "./state";
 
@@ -31,23 +31,38 @@ async function fetchNewItems(task: ScheduledTask): Promise<WatchItem[]> {
   const tickers = task.watch?.tickers || [];
   const sources = task.watch?.sources || [];
 
-  const queryParts: string[] = [];
-  queryParts.push(
-    ...keywords,
-    ...tickers.map((t) => `$${t}`),
-    ...sources.map((s) => `from:${s.replace(/^@/, "")}`)
-  );
-
-  if (queryParts.length === 0) {
+  if (
+    keywords.length === 0 &&
+    tickers.length === 0 &&
+    sources.length === 0
+  ) {
     return [];
   }
 
-  const query = queryParts.join(" ");
+  const watchDescription = [
+    tickers.length ? `Tickers: ${tickers.join(", ")}` : undefined,
+    keywords.length ? `Keywords: ${keywords.join(", ")}` : undefined,
+    sources.length ? `Sources: ${sources.join(", ")}` : undefined,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const messages: H1dr4Message[] = [
+    {
+      role: "system",
+      content:
+        "You are an event detection agent. Use any tools at your disposal (live_search, RSS, reasoning) to find the latest public posts or news that match the user's watchlist. Return each distinct item on its own line with a brief summary and link if available.",
+    },
+    {
+      role: "user",
+      content: `${watchDescription}\nReturn only new items discovered during this run.`,
+    },
+  ];
+
   try {
-    const response = await client.search(query, {
-      mode: "on",
-      max_search_results: 10,
-    } as any);
+    const response = await client.chat(messages, [], undefined, {
+      search_parameters: { mode: "on", max_search_results: 10 },
+    });
     const content = response.choices[0]?.message.content || "";
     const lines = content.split(/\n+/).map((l) => l.trim()).filter(Boolean);
     const items: WatchItem[] = [];
@@ -61,7 +76,7 @@ async function fetchNewItems(task: ScheduledTask): Promise<WatchItem[]> {
     }
     return items;
   } catch (error) {
-    console.warn(`Live search failed: ${(error as Error).message}`);
+    console.warn(`Query failed: ${(error as Error).message}`);
     return [];
   }
 }

--- a/src/schedule/watch.ts
+++ b/src/schedule/watch.ts
@@ -1,0 +1,47 @@
+import chalk from "chalk";
+import { ScheduledTask, ImpactLevel } from "./config";
+
+interface WatchItem {
+  summary: string;
+  metadata: Record<string, string>;
+}
+
+async function fetchNewItems(task: ScheduledTask): Promise<WatchItem[]> {
+  // Placeholder for event detection logic integrating RSS, MCP, etc.
+  const keywords = task.watch?.keywords?.join(", ");
+  const tickers = task.watch?.tickers?.join(", ");
+  if (!keywords && !tickers) {
+    return [];
+  }
+  const meta: Record<string, string> = {};
+  if (keywords) meta.keywords = keywords;
+  if (tickers) meta.tickers = tickers;
+  return [
+    {
+      summary: `Detected event for ${keywords || tickers}`,
+      metadata: meta,
+    },
+  ];
+}
+
+function analyzeImpact(_item: WatchItem): ImpactLevel {
+  // Stub analysis step: replace with sentiment/price correlation logic
+  return "High";
+}
+
+export async function runWatchTask(task: ScheduledTask): Promise<void> {
+  const items = await fetchNewItems(task);
+  if (items.length === 0) return;
+  const threshold = task.watch?.threshold || "Low";
+  const levels: Record<ImpactLevel, number> = { Low: 1, "Mid-High": 2, High: 3 };
+  for (const item of items) {
+    const impact = analyzeImpact(item);
+    if (levels[impact] >= levels[threshold]) {
+      console.log(
+        chalk.yellow(
+          `[Alert] ${item.summary} -> Estimated ${impact} impact`
+        )
+      );
+    }
+  }
+}

--- a/src/schedule/watch.ts
+++ b/src/schedule/watch.ts
@@ -1,5 +1,5 @@
 import chalk from "chalk";
-import Parser from "rss-parser";
+import { H1dr4Client } from "../h1dr4/client";
 import { ScheduledTask, ImpactLevel } from "./config";
 import { loadWatchState, saveWatchState } from "./state";
 
@@ -15,64 +15,61 @@ function detectContractAddress(text: string): string | undefined {
 }
 
 async function fetchNewItems(task: ScheduledTask): Promise<WatchItem[]> {
-  const parser = new Parser();
-  const items: WatchItem[] = [];
-
-  const keywords = task.watch?.keywords?.map((k) => k.toLowerCase());
-  const tickers = task.watch?.tickers?.map((t) => t.toLowerCase());
-  const sources = task.watch?.sources || [];
-
-  if (sources.length === 0) return items;
-
-  for (const rawSource of sources) {
-    const handle = rawSource.replace(/^@/, "");
-    const url = `https://nitter.net/${handle}/rss`;
-    try {
-      const feed = await parser.parseURL(url);
-      for (const entry of feed.items || []) {
-        const content = `${entry.title || ""} ${
-          entry.contentSnippet || ""
-        }`.trim();
-        const lower = content.toLowerCase();
-
-        const matchesKeyword = keywords
-          ? keywords.some((k) => lower.includes(k))
-          : false;
-        const matchesTicker = tickers
-          ? tickers.some((t) => lower.includes(t))
-          : false;
-        const contract = detectContractAddress(content);
-
-        if (keywords || tickers) {
-          if (!matchesKeyword && !matchesTicker && !contract) continue;
-        } else if (!contract) {
-          continue;
-        }
-
-        const meta: Record<string, string> = { source: rawSource };
-        if (entry.link) meta.link = entry.link;
-        if (contract) meta.contractAddress = contract;
-
-        items.push({
-          id: entry.id || entry.guid || entry.link || entry.pubDate || content,
-          summary: content || "New post",
-          metadata: meta,
-        });
-      }
-    } catch (error) {
-      console.warn(
-        `Failed to fetch source ${rawSource}: ${(error as Error).message}`
-      );
-    }
+  const apiKey = process.env.GROK_API_KEY;
+  if (!apiKey) {
+    console.warn("GROK_API_KEY not set; skipping watch task");
+    return [];
   }
 
-  return items;
+  const client = new H1dr4Client(
+    apiKey,
+    process.env.H1DR4_MODEL,
+    process.env.GROK_BASE_URL
+  );
+
+  const keywords = task.watch?.keywords || [];
+  const tickers = task.watch?.tickers || [];
+  const sources = task.watch?.sources || [];
+
+  const queryParts: string[] = [];
+  queryParts.push(
+    ...keywords,
+    ...tickers.map((t) => `$${t}`),
+    ...sources.map((s) => `from:${s.replace(/^@/, "")}`)
+  );
+
+  if (queryParts.length === 0) {
+    return [];
+  }
+
+  const query = queryParts.join(" ");
+  try {
+    const response = await client.search(query, {
+      mode: "on",
+      max_search_results: 10,
+    } as any);
+    const content = response.choices[0]?.message.content || "";
+    const lines = content.split(/\n+/).map((l) => l.trim()).filter(Boolean);
+    const items: WatchItem[] = [];
+    for (const line of lines) {
+      const contract = detectContractAddress(line);
+      const meta: Record<string, string> = {};
+      const urlMatch = line.match(/https?:\/\/\S+/);
+      if (urlMatch) meta.link = urlMatch[0];
+      if (contract) meta.contractAddress = contract;
+      items.push({ id: line, summary: line, metadata: meta });
+    }
+    return items;
+  } catch (error) {
+    console.warn(`Live search failed: ${(error as Error).message}`);
+    return [];
+  }
 }
 
 function analyzeImpact(item: WatchItem): ImpactLevel {
-  const keywords = item.metadata.keywords?.toLowerCase() || "";
+  const lower = item.summary.toLowerCase();
   if (item.metadata.contractAddress) return "High";
-  if (keywords.includes("trump") || keywords.includes("fed")) {
+  if (lower.includes("trump") || lower.includes("fed")) {
     return "Mid-High";
   }
   return "Low";

--- a/src/schedule/watch.ts
+++ b/src/schedule/watch.ts
@@ -9,11 +9,6 @@ interface WatchItem {
   metadata: Record<string, string>;
 }
 
-function detectContractAddress(text: string): string | undefined {
-  const match = text.match(/0x[a-fA-F0-9]{40}/);
-  return match ? match[0] : undefined;
-}
-
 async function fetchNewItems(task: ScheduledTask): Promise<WatchItem[]> {
   const apiKey = process.env.GROK_API_KEY;
   if (!apiKey) {
@@ -67,11 +62,9 @@ async function fetchNewItems(task: ScheduledTask): Promise<WatchItem[]> {
     const lines = content.split(/\n+/).map((l) => l.trim()).filter(Boolean);
     const items: WatchItem[] = [];
     for (const line of lines) {
-      const contract = detectContractAddress(line);
       const meta: Record<string, string> = {};
       const urlMatch = line.match(/https?:\/\/\S+/);
       if (urlMatch) meta.link = urlMatch[0];
-      if (contract) meta.contractAddress = contract;
       items.push({ id: line, summary: line, metadata: meta });
     }
     return items;
@@ -81,13 +74,39 @@ async function fetchNewItems(task: ScheduledTask): Promise<WatchItem[]> {
   }
 }
 
-function analyzeImpact(item: WatchItem): ImpactLevel {
-  const lower = item.summary.toLowerCase();
-  if (item.metadata.contractAddress) return "High";
-  if (lower.includes("trump") || lower.includes("fed")) {
-    return "Mid-High";
+async function analyzeImpact(
+  item: WatchItem,
+  task: ScheduledTask
+): Promise<ImpactLevel> {
+  const criteria = task.watch?.criteria;
+  if (!criteria) return "High";
+  const apiKey = process.env.GROK_API_KEY;
+  if (!apiKey) return "Low";
+  const client = new H1dr4Client(
+    apiKey,
+    process.env.H1DR4_MODEL,
+    process.env.GROK_BASE_URL
+  );
+  const messages: H1dr4Message[] = [
+    {
+      role: "system",
+      content:
+        "You rate whether an item meets the user's alert criteria. Respond with only one of: Low, Mid-High, High.",
+    },
+    {
+      role: "user",
+      content: `Criteria: ${criteria}\nItem: ${item.summary}`,
+    },
+  ];
+  try {
+    const resp = await client.chat(messages);
+    const text = resp.choices[0]?.message.content?.toLowerCase() || "";
+    if (text.includes("mid")) return "Mid-High";
+    if (text.includes("high")) return "High";
+    return "Low";
+  } catch {
+    return "Low";
   }
-  return "Low";
 }
 
 export async function runWatchTask(task: ScheduledTask): Promise<void> {
@@ -99,7 +118,7 @@ export async function runWatchTask(task: ScheduledTask): Promise<void> {
   const threshold = task.watch?.threshold || "Low";
   const levels: Record<ImpactLevel, number> = { Low: 1, "Mid-High": 2, High: 3 };
   for (const item of unseen) {
-    const impact = analyzeImpact(item);
+    const impact = await analyzeImpact(item, task);
     if (levels[impact] >= levels[threshold]) {
       console.log(
         chalk.yellow(

--- a/src/schedule/watch.ts
+++ b/src/schedule/watch.ts
@@ -1,40 +1,61 @@
 import chalk from "chalk";
 import { ScheduledTask, ImpactLevel } from "./config";
+import { loadWatchState, saveWatchState } from "./state";
 
 interface WatchItem {
+  id: string;
   summary: string;
   metadata: Record<string, string>;
+}
+
+function detectContractAddress(text: string): string | undefined {
+  const match = text.match(/0x[a-fA-F0-9]{40}/);
+  return match ? match[0] : undefined;
 }
 
 async function fetchNewItems(task: ScheduledTask): Promise<WatchItem[]> {
   // Placeholder for event detection logic integrating RSS, MCP, etc.
   const keywords = task.watch?.keywords?.join(", ");
   const tickers = task.watch?.tickers?.join(", ");
-  if (!keywords && !tickers) {
+  const sources = task.watch?.sources?.join(", ");
+  if (!keywords && !tickers && !sources) {
     return [];
   }
   const meta: Record<string, string> = {};
   if (keywords) meta.keywords = keywords;
   if (tickers) meta.tickers = tickers;
+  if (sources) meta.sources = sources;
+  // Simulate a detected summary
+  const summary = `Detected event for ${keywords || tickers || sources}`;
+  const contract = detectContractAddress(summary);
+  if (contract) meta.contractAddress = contract;
   return [
     {
-      summary: `Detected event for ${keywords || tickers}`,
+      id: Date.now().toString(),
+      summary,
       metadata: meta,
     },
   ];
 }
 
-function analyzeImpact(_item: WatchItem): ImpactLevel {
-  // Stub analysis step: replace with sentiment/price correlation logic
-  return "High";
+function analyzeImpact(item: WatchItem): ImpactLevel {
+  const keywords = item.metadata.keywords?.toLowerCase() || "";
+  if (item.metadata.contractAddress) return "High";
+  if (keywords.includes("trump") || keywords.includes("fed")) {
+    return "Mid-High";
+  }
+  return "Low";
 }
 
 export async function runWatchTask(task: ScheduledTask): Promise<void> {
+  const state = loadWatchState();
+  const taskState = state[task.id] || { seenIds: [] };
   const items = await fetchNewItems(task);
-  if (items.length === 0) return;
+  const unseen = items.filter((i) => !taskState.seenIds.includes(i.id));
+  if (unseen.length === 0) return;
   const threshold = task.watch?.threshold || "Low";
   const levels: Record<ImpactLevel, number> = { Low: 1, "Mid-High": 2, High: 3 };
-  for (const item of items) {
+  for (const item of unseen) {
     const impact = analyzeImpact(item);
     if (levels[impact] >= levels[threshold]) {
       console.log(
@@ -43,5 +64,8 @@ export async function runWatchTask(task: ScheduledTask): Promise<void> {
         )
       );
     }
+    taskState.seenIds.push(item.id);
   }
+  state[task.id] = taskState;
+  saveWatchState(state);
 }


### PR DESCRIPTION
## Summary
- extend scheduler to track watchlists with optional impact thresholds
- add watch runner for basic event detection and alerting
- expose `schedule watch` CLI subcommand for defining watchlists

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b994e94748832cb204488e8a70bcfb