### PR TITLE
feat: add alert scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ h1dr4 schedule alerts
 h1dr4 schedule remove TASK_ID
 ```
 
-In the interactive CLI, press **Tab** twice quickly to toggle a live list of scheduled tasks and alerts.
+In the interactive CLI, press **Tab** twice quickly or **Ctrl+Shift+S** to toggle a live list of scheduled tasks and alerts. The status bar shows the number of scheduled jobs (⏰) and triggered alerts (🚨).
 
 Scheduled tasks run even if the CLI is closed. A background daemon watches
 `~/.h1dr4/schedules.json` and launches the command or query at the specified time. If the

--- a/README.md
+++ b/README.md
@@ -446,18 +446,27 @@ h1dr4 rss remove myfeed
 ### Scheduling Tasks
 
 ```bash
-# Schedule a command using cron syntax
+# Schedule a shell command using cron syntax
 h1dr4 schedule add "0 9 * * 1" "echo 'weekly task'"
+
+# Schedule a natural-language query in headless mode
+h1dr4 schedule add "0 * * * *" "h1dr4 -p 'remind me to stretch'"
+
+# Schedule an alert that notifies when output matches criteria
+h1dr4 schedule alert "*/5 * * * *" "curl -s https://example.com/status" --criteria "DOWN"
 
 # List scheduled tasks
 h1dr4 schedule list
+
+# Show triggered alerts
+h1dr4 schedule alerts
 
 # Remove a task
 h1dr4 schedule remove TASK_ID
 ```
 
 Scheduled tasks run even if the CLI is closed. A background daemon watches
-`~/.h1dr4/schedules.json` and launches the command at the specified time. If the
+`~/.h1dr4/schedules.json` and launches the command or query at the specified time. If the
 chat interface is open, output is printed directly in the terminal. Otherwise,
 the daemon attempts to open a new terminal window to execute the command.
 

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ h1dr4 schedule alerts
 h1dr4 schedule remove TASK_ID
 ```
 
-In the interactive CLI, press **Ctrl+Shift+S** to toggle a live list of scheduled tasks and alerts.
+In the interactive CLI, press **Ctrl+Alt+S** to toggle a live list of scheduled tasks and alerts.
 
 Scheduled tasks run even if the CLI is closed. A background daemon watches
 `~/.h1dr4/schedules.json` and launches the command or query at the specified time. If the

--- a/README.md
+++ b/README.md
@@ -455,6 +455,9 @@ h1dr4 schedule add "0 * * * *" "h1dr4 -p 'remind me to stretch'"
 # Schedule an alert evaluated by Grok against natural-language criteria
 h1dr4 schedule alert "*/5 * * * *" "curl -s https://example.com/status" --criteria "service is down"
 
+# Schedule an alert with a long-lived popup window
+h1dr4 schedule alert "*/5 * * * *" "curl -s https://example.com/status" --criteria "service is down" --popup long
+
 # Schedule an alert that uses exact substring matching
 h1dr4 schedule alert-exact "*/5 * * * *" "curl -s https://example.com/status" --criteria "DOWN"
 

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ h1dr4 schedule alerts
 h1dr4 schedule remove TASK_ID
 ```
 
-In the interactive CLI, press **Shift+S** to toggle a live list of scheduled tasks and alerts.
+In the interactive CLI, press **Ctrl+Shift+S** to toggle a live list of scheduled tasks and alerts.
 
 Scheduled tasks run even if the CLI is closed. A background daemon watches
 `~/.h1dr4/schedules.json` and launches the command or query at the specified time. If the

--- a/README.md
+++ b/README.md
@@ -471,6 +471,9 @@ h1dr4 schedule alerts
 h1dr4 schedule remove TASK_ID
 ```
 
+When an alert's criteria is met, a separate terminal window opens and prints
+`ALERT 🚨` followed by the matching output so you can't miss it.
+
 In the interactive CLI, press **Tab** twice quickly or **Ctrl+Shift+S** to toggle a live list of scheduled tasks and alerts. The status bar shows the number of scheduled jobs (⏰) and triggered alerts (🚨).
 
 Scheduled tasks run even if the CLI is closed. A background daemon watches

--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ h1dr4 schedule alerts
 h1dr4 schedule remove TASK_ID
 ```
 
-In the interactive CLI, press **Ctrl+Alt+S** to toggle a live list of scheduled tasks and alerts.
+In the interactive CLI, press **Tab** twice quickly to toggle a live list of scheduled tasks and alerts.
 
 Scheduled tasks run even if the CLI is closed. A background daemon watches
 `~/.h1dr4/schedules.json` and launches the command or query at the specified time. If the

--- a/README.md
+++ b/README.md
@@ -455,8 +455,11 @@ h1dr4 schedule add "0 * * * *" "h1dr4 -p 'remind me to stretch'"
 # Schedule an alert evaluated by Grok against natural-language criteria
 h1dr4 schedule alert "*/5 * * * *" "curl -s https://example.com/status" --criteria "service is down"
 
-# Schedule an alert that uses exact substring matching
+# Schedule an alert that uses exact substring or regex matching
 h1dr4 schedule alert-exact "*/5 * * * *" "curl -s https://example.com/status" --criteria "DOWN"
+
+# Schedule an alert using a regex pattern
+h1dr4 schedule alert-exact "0 9 * * 1" "curl -s https://example.com/status" --criteria "^ERROR" 
 
 # List scheduled tasks
 h1dr4 schedule list

--- a/README.md
+++ b/README.md
@@ -468,6 +468,8 @@ h1dr4 schedule alerts
 h1dr4 schedule remove TASK_ID
 ```
 
+In the interactive CLI, press **Shift+S** to toggle a live list of scheduled tasks and alerts.
+
 Scheduled tasks run even if the CLI is closed. A background daemon watches
 `~/.h1dr4/schedules.json` and launches the command or query at the specified time. If the
 chat interface is open, output is printed directly in the terminal. Otherwise,

--- a/README.md
+++ b/README.md
@@ -452,8 +452,11 @@ h1dr4 schedule add "0 9 * * 1" "echo 'weekly task'"
 # Schedule a natural-language query in headless mode
 h1dr4 schedule add "0 * * * *" "h1dr4 -p 'remind me to stretch'"
 
-# Schedule an alert that notifies when output matches criteria
-h1dr4 schedule alert "*/5 * * * *" "curl -s https://example.com/status" --criteria "DOWN"
+# Schedule an alert evaluated by Grok against natural-language criteria
+h1dr4 schedule alert "*/5 * * * *" "curl -s https://example.com/status" --criteria "service is down"
+
+# Schedule an alert that uses exact substring matching
+h1dr4 schedule alert-exact "*/5 * * * *" "curl -s https://example.com/status" --criteria "DOWN"
 
 # List scheduled tasks
 h1dr4 schedule list

--- a/README.md
+++ b/README.md
@@ -455,11 +455,8 @@ h1dr4 schedule add "0 * * * *" "h1dr4 -p 'remind me to stretch'"
 # Schedule an alert evaluated by Grok against natural-language criteria
 h1dr4 schedule alert "*/5 * * * *" "curl -s https://example.com/status" --criteria "service is down"
 
-# Schedule an alert that uses exact substring or regex matching
+# Schedule an alert that uses exact substring matching
 h1dr4 schedule alert-exact "*/5 * * * *" "curl -s https://example.com/status" --criteria "DOWN"
-
-# Schedule an alert using a regex pattern
-h1dr4 schedule alert-exact "0 9 * * 1" "curl -s https://example.com/status" --criteria "^ERROR" 
 
 # List scheduled tasks
 h1dr4 schedule list

--- a/src/agent/h1dr4-agent.ts
+++ b/src/agent/h1dr4-agent.ts
@@ -164,8 +164,8 @@ TASK PLANNING WITH TODO LISTS:
 
 SCHEDULING TASKS:
 - Schedule shell commands or agent queries using cron syntax with \`h1dr4 schedule add "<cron>" "<command>"\` (for queries, use headless mode like \`h1dr4 -p "<question>"\`)
-- Use \`h1dr4 schedule alert "<cron>" "<command>" --criteria "<description>"\` to run a command or query at the given interval and trigger an ALERT 🚨 when Grok determines the output meets the natural-language criteria. Grok uses a dedicated yes/no tool for this evaluation
-- For literal substring checks, use \`h1dr4 schedule alert-exact "<cron>" "<command>" --criteria "<text>"\`
+ - Use \`h1dr4 schedule alert "<cron>" "<command>" --criteria "<description>"\` to run a command or query at the given interval and trigger an ALERT 🚨 when Grok determines the output meets the natural-language criteria. Grok must respond with **YES** or **NO**
+ - For literal substring checks, use \`h1dr4 schedule alert-exact "<cron>" "<command>" --criteria "<text>"\`
 - Use \`h1dr4 schedule list\` to view existing tasks
 - View past alerts with \`h1dr4 schedule alerts\`; duplicates are automatically suppressed
 - Use \`h1dr4 schedule remove <id>\` to cancel a task; to modify one, remove it and add a new entry

--- a/src/agent/h1dr4-agent.ts
+++ b/src/agent/h1dr4-agent.ts
@@ -164,7 +164,8 @@ TASK PLANNING WITH TODO LISTS:
 
 SCHEDULING TASKS:
 - Schedule shell commands or agent queries using cron syntax with \`h1dr4 schedule add "<cron>" "<command>"\` (for queries, use headless mode like \`h1dr4 -p "<question>"\`)
-- Use \`h1dr4 schedule alert "<cron>" "<command>" --criteria "<pattern>"\` to run a command or query at the given interval and trigger an ALERT 🚨 message when output matches the criteria
+- Use \`h1dr4 schedule alert "<cron>" "<command>" --criteria "<description>"\` to run a command or query at the given interval and trigger an ALERT 🚨 when Grok determines the output meets the natural-language criteria
+- For literal substring checks, use \`h1dr4 schedule alert-exact "<cron>" "<command>" --criteria "<text>"\`
 - Use \`h1dr4 schedule list\` to view existing tasks
 - View past alerts with \`h1dr4 schedule alerts\`; duplicates are automatically suppressed
 - Use \`h1dr4 schedule remove <id>\` to cancel a task; to modify one, remove it and add a new entry

--- a/src/agent/h1dr4-agent.ts
+++ b/src/agent/h1dr4-agent.ts
@@ -164,12 +164,12 @@ TASK PLANNING WITH TODO LISTS:
 
 SCHEDULING TASKS:
 - Schedule shell commands or agent queries using cron syntax with \`h1dr4 schedule add "<cron>" "<command>"\` (for queries, use headless mode like \`h1dr4 -p "<question>"\`)
- - Use \`h1dr4 schedule alert "<cron>" "<command>" --criteria "<description>"\` to run a command or query at the given interval and trigger an ALERT 🚨 when Grok determines the output meets the natural-language criteria. Grok must respond with **YES** or **NO**
- - For literal substring checks, use \`h1dr4 schedule alert-exact "<cron>" "<command>" --criteria "<text>"\`
+- Use \`h1dr4 schedule alert "<cron>" "<command>" --criteria "<description>" [--popup long|short]\` to run a command or query at the given interval and trigger an ALERT 🚨 when Grok determines the output meets the natural-language criteria. \`--popup long\` keeps the alert window open; \`--popup short\` (default) closes it after ~30s. Grok must respond with **YES** or **NO**
+- For literal substring checks, use \`h1dr4 schedule alert-exact "<cron>" "<command>" --criteria "<text>" [--popup long|short]\`
 - Use \`h1dr4 schedule list\` to view existing tasks
 - View past alerts with \`h1dr4 schedule alerts\`; duplicates are automatically suppressed
 - Use \`h1dr4 schedule remove <id>\` to cancel a task; to modify one, remove it and add a new entry
-- Tasks are stored in \`~/.h1dr4/schedules.json\`, run automatically when due, and bypass confirmation
+- Tasks are stored in \`~/.h1dr4/schedules.json\`, run automatically when due, bypass confirmation, and may use reasoning or other tools without additional prompts
 
 USER CONFIRMATION SYSTEM:
 File operations (create_file, str_replace_editor) and bash commands will automatically request user confirmation before execution. The confirmation system will show users the actual content or command before they decide. Users can choose to approve individual operations or approve all operations of that type for the session.

--- a/src/agent/h1dr4-agent.ts
+++ b/src/agent/h1dr4-agent.ts
@@ -163,9 +163,9 @@ TASK PLANNING WITH TODO LISTS:
 - Always create todos with priorities: 'high' (🔴), 'medium' (🟡), 'low' (🟢)
 
 SCHEDULING TASKS:
-- Schedule shell commands with \`h1dr4 schedule add "<cron>" "<command>"\`
+- Schedule shell commands or agent queries using cron syntax with \`h1dr4 schedule add "<cron>" "<command>"\` (for queries, use headless mode like \`h1dr4 -p "<question>"\`)
+- Use \`h1dr4 schedule alert "<cron>" "<command>" --criteria "<pattern>"\` to run a command or query at the given interval and trigger an ALERT 🚨 message when output matches the criteria
 - Use \`h1dr4 schedule list\` to view existing tasks
-- Use \`h1dr4 schedule alert "<cron>" "<command>" --criteria "<pattern>"\` to set up an alert that runs the command at the given interval and triggers an ALERT 🚨 message when output matches the criteria
 - View past alerts with \`h1dr4 schedule alerts\`; duplicates are automatically suppressed
 - Use \`h1dr4 schedule remove <id>\` to cancel a task; to modify one, remove it and add a new entry
 - Tasks are stored in \`~/.h1dr4/schedules.json\`, run automatically when due, and bypass confirmation

--- a/src/agent/h1dr4-agent.ts
+++ b/src/agent/h1dr4-agent.ts
@@ -164,7 +164,7 @@ TASK PLANNING WITH TODO LISTS:
 
 SCHEDULING TASKS:
 - Schedule shell commands or agent queries using cron syntax with \`h1dr4 schedule add "<cron>" "<command>"\` (for queries, use headless mode like \`h1dr4 -p "<question>"\`)
-- Use \`h1dr4 schedule alert "<cron>" "<command>" --criteria "<description>"\` to run a command or query at the given interval and trigger an ALERT 🚨 when Grok determines the output meets the natural-language criteria
+- Use \`h1dr4 schedule alert "<cron>" "<command>" --criteria "<description>"\` to run a command or query at the given interval and trigger an ALERT 🚨 when Grok determines the output meets the natural-language criteria. Grok uses a dedicated yes/no tool for this evaluation
 - For literal substring checks, use \`h1dr4 schedule alert-exact "<cron>" "<command>" --criteria "<text>"\`
 - Use \`h1dr4 schedule list\` to view existing tasks
 - View past alerts with \`h1dr4 schedule alerts\`; duplicates are automatically suppressed

--- a/src/agent/h1dr4-agent.ts
+++ b/src/agent/h1dr4-agent.ts
@@ -165,6 +165,8 @@ TASK PLANNING WITH TODO LISTS:
 SCHEDULING TASKS:
 - Schedule shell commands with \`h1dr4 schedule add "<cron>" "<command>"\`
 - Use \`h1dr4 schedule list\` to view existing tasks
+- Use \`h1dr4 schedule alert "<cron>" "<command>" --criteria "<pattern>"\` to set up an alert that runs the command at the given interval and triggers an ALERT 🚨 message when output matches the criteria
+- View past alerts with \`h1dr4 schedule alerts\`; duplicates are automatically suppressed
 - Use \`h1dr4 schedule remove <id>\` to cancel a task; to modify one, remove it and add a new entry
 - Tasks are stored in \`~/.h1dr4/schedules.json\`, run automatically when due, and bypass confirmation
 

--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -135,9 +135,17 @@ function ensureDaemonRunning(): void {
     process.kill(pid, 0);
     return; // daemon already running
   } catch {}
-  const child = spawn(process.execPath, [DAEMON_PATH], {
-    detached: true,
-    stdio: "ignore",
-  });
-  child.unref();
+  const logDir = path.join(os.homedir(), ".h1dr4");
+  const logPath = path.join(logDir, "daemon.log");
+  try {
+    fs.mkdirSync(logDir, { recursive: true });
+    const out = fs.openSync(logPath, "a");
+    const child = spawn(process.execPath, [DAEMON_PATH], {
+      detached: true,
+      stdio: ["ignore", out, out],
+    });
+    child.unref();
+  } catch (err) {
+    console.error(`Failed to start daemon: ${err}`);
+  }
 }

--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -26,17 +26,20 @@ export function createScheduleCommand(): Command {
   scheduleCommand
     .command("alert <cron> <cmd...>")
     .requiredOption("-c, --criteria <criteria>", "Natural-language criteria for Grok evaluation")
+    .option("--popup <mode>", "Alert window: short (30s) or long", "short")
     .description(
       "Schedule a command that triggers alerts when Grok determines the output meets the criteria",
     )
-    .action((cron: string, cmd: string[], options: { criteria: string }) => {
+    .action((cron: string, cmd: string[], options: { criteria: string; popup: string }) => {
       const command = cmd.join(" ");
+      const alertDuration = options.popup === "long" ? 0 : 30000;
       const task = {
         id: randomUUID(),
         cron,
         command,
         type: "alert" as const,
         criteria: options.criteria,
+        alertDuration,
       };
       addSchedule(task);
       reloadSchedulers();
@@ -46,17 +49,20 @@ export function createScheduleCommand(): Command {
   scheduleCommand
     .command("alert-exact <cron> <cmd...>")
     .requiredOption("-c, --criteria <criteria>", "Substring to match (case-insensitive)")
+    .option("--popup <mode>", "Alert window: short (30s) or long", "short")
     .description(
       "Schedule a command that triggers alerts only when output contains the exact criteria substring",
     )
-    .action((cron: string, cmd: string[], options: { criteria: string }) => {
+    .action((cron: string, cmd: string[], options: { criteria: string; popup: string }) => {
       const command = cmd.join(" ");
+      const alertDuration = options.popup === "long" ? 0 : 30000;
       const task = {
         id: randomUUID(),
         cron,
         command,
         type: "alert-exact" as const,
         criteria: options.criteria,
+        alertDuration,
       };
       addSchedule(task);
       reloadSchedulers();
@@ -76,7 +82,10 @@ export function createScheduleCommand(): Command {
       tasks.forEach((t) => {
         if (t.type === "alert" || t.type === "alert-exact") {
           const mode = t.type === "alert-exact" ? "exact" : "grok";
-          console.log(`${t.id}: ${t.cron} -> ${t.command} [alert-${mode}: ${t.criteria}]`);
+          const popup = t.alertDuration === 0 ? "long" : "short";
+          console.log(
+            `${t.id}: ${t.cron} -> ${t.command} [alert-${mode}: ${t.criteria}; popup: ${popup}]`,
+          );
         } else {
           console.log(`${t.id}: ${t.cron} -> ${t.command}`);
         }

--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -95,7 +95,13 @@ export function createScheduleCommand(): Command {
       }
       console.log(chalk.bold("Triggered alerts:"));
       for (const [, messages] of entries) {
-        messages.forEach((m) => console.log(`ALERT 🚨 ${m}`));
+        messages.forEach((m) => {
+          if (m.startsWith("ERROR:") || m.startsWith("NO MATCH:")) {
+            console.log(m);
+          } else {
+            console.log(`ALERT 🚨 ${m}`);
+          }
+        });
       }
     });
 
@@ -112,32 +118,18 @@ export function createScheduleCommand(): Command {
 }
 
 const PID_FILE = path.join(os.homedir(), ".h1dr4", "schedule.pid");
-const UI_PID_FILE = path.join(os.homedir(), ".h1dr4", "ui.pid");
 const DAEMON_PATH = path.join(__dirname, "../schedule/daemon.js");
 
 function reloadSchedulers(): void {
-  let notified = false;
-  try {
-    const uiPid = parseInt(fs.readFileSync(UI_PID_FILE, "utf8"), 10);
-    process.kill(uiPid, "SIGUSR1");
-    notified = true;
-  } catch {}
   try {
     const pid = parseInt(fs.readFileSync(PID_FILE, "utf8"), 10);
     process.kill(pid, "SIGUSR1");
-    notified = true;
-  } catch {}
-  if (!notified) {
+  } catch {
     ensureDaemonRunning();
   }
 }
 
 function ensureDaemonRunning(): void {
-  try {
-    const uiPid = parseInt(fs.readFileSync(UI_PID_FILE, "utf8"), 10);
-    process.kill(uiPid, 0);
-    return; // UI active, skip daemon
-  } catch {}
   try {
     const pid = parseInt(fs.readFileSync(PID_FILE, "utf8"), 10);
     process.kill(pid, 0);

--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -182,6 +182,8 @@ function ensureDaemonRunning(): void {
     const child = spawn(process.execPath, [DAEMON_PATH], {
       detached: true,
       stdio: ["ignore", out, out],
+      cwd: path.join(__dirname, "..", ".."),
+      env: process.env,
     });
     child.unref();
   } catch (err) {

--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -25,8 +25,10 @@ export function createScheduleCommand(): Command {
 
   scheduleCommand
     .command("alert <cron> <cmd...>")
-    .requiredOption("-c, --criteria <criteria>", "Criteria to match")
-    .description("Schedule a command that triggers alerts when output matches criteria")
+    .requiredOption("-c, --criteria <criteria>", "Natural-language criteria for Grok evaluation")
+    .description(
+      "Schedule a command that triggers alerts when Grok determines the output meets the criteria",
+    )
     .action((cron: string, cmd: string[], options: { criteria: string }) => {
       const command = cmd.join(" ");
       const task = {
@@ -42,6 +44,26 @@ export function createScheduleCommand(): Command {
     });
 
   scheduleCommand
+    .command("alert-exact <cron> <cmd...>")
+    .requiredOption("-c, --criteria <criteria>", "Substring to match (case-insensitive)")
+    .description(
+      "Schedule a command that triggers alerts only when output contains the exact criteria substring",
+    )
+    .action((cron: string, cmd: string[], options: { criteria: string }) => {
+      const command = cmd.join(" ");
+      const task = {
+        id: randomUUID(),
+        cron,
+        command,
+        type: "alert-exact" as const,
+        criteria: options.criteria,
+      };
+      addSchedule(task);
+      reloadSchedulers();
+      console.log(chalk.green(`✓ Scheduled exact-match alert ${task.id}`));
+    });
+
+  scheduleCommand
     .command("list")
     .description("List scheduled tasks")
     .action(() => {
@@ -52,8 +74,9 @@ export function createScheduleCommand(): Command {
       }
       console.log(chalk.bold("Scheduled tasks:"));
       tasks.forEach((t) => {
-        if (t.type === "alert") {
-          console.log(`${t.id}: ${t.cron} -> ${t.command} [alert: ${t.criteria}]`);
+        if (t.type === "alert" || t.type === "alert-exact") {
+          const mode = t.type === "alert-exact" ? "exact" : "grok";
+          console.log(`${t.id}: ${t.cron} -> ${t.command} [alert-${mode}: ${t.criteria}]`);
         } else {
           console.log(`${t.id}: ${t.cron} -> ${t.command}`);
         }

--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -106,6 +106,45 @@ export function createScheduleCommand(): Command {
     });
 
   scheduleCommand
+    .command("watch")
+    .description("Watch alert log for new entries in real time")
+    .action(() => {
+      const logPath = path.join(os.homedir(), ".h1dr4", "alerts.json");
+      fs.mkdirSync(path.dirname(logPath), { recursive: true });
+      if (!fs.existsSync(logPath)) {
+        fs.writeFileSync(logPath, "{}", "utf8");
+      }
+
+      console.log(chalk.dim(`Watching ${logPath} (press Ctrl+C to exit)`));
+
+      let previous = loadAlerts();
+      const printMessages = (messages: string[]) => {
+        messages.forEach((m) => {
+          if (m.startsWith("ERROR:") || m.startsWith("NO MATCH:")) {
+            console.log(m);
+          } else {
+            console.log(`ALERT 🚨 ${m}`);
+          }
+        });
+      };
+
+      // Print existing alerts once at startup
+      Object.values(previous).forEach(printMessages);
+
+      fs.watchFile(logPath, { interval: 500 }, () => {
+        const current = loadAlerts();
+        for (const [id, msgs] of Object.entries(current)) {
+          const prev = previous[id] || [];
+          const newMsgs = msgs.slice(prev.length);
+          if (newMsgs.length > 0) {
+            printMessages(newMsgs);
+          }
+        }
+        previous = current;
+      });
+    });
+
+  scheduleCommand
     .command("remove <id>")
     .description("Remove a scheduled task")
     .action((id: string) => {

--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -96,10 +96,13 @@ export function createScheduleCommand(): Command {
       console.log(chalk.bold("Triggered alerts:"));
       for (const [, messages] of entries) {
         messages.forEach((m) => {
-          if (m.startsWith("ERROR:") || m.startsWith("NO MATCH:")) {
-            console.log(m);
+          if (m.startsWith("RUN:")) {
+            return; // skip run logs in summary view
+          }
+          if (m.startsWith("ALERT:")) {
+            console.log(`ALERT 🚨 ${m.slice(6).trim()}`);
           } else {
-            console.log(`ALERT 🚨 ${m}`);
+            console.log(m);
           }
         });
       }
@@ -120,10 +123,14 @@ export function createScheduleCommand(): Command {
       let previous = loadAlerts();
       const printMessages = (messages: string[]) => {
         messages.forEach((m) => {
-          if (m.startsWith("ERROR:") || m.startsWith("NO MATCH:")) {
+          if (m.startsWith("ALERT:")) {
+            console.log(`ALERT 🚨 ${m.slice(6).trim()}`);
+          } else if (m.startsWith("NO MATCH:") || m.startsWith("ERROR:")) {
             console.log(m);
+          } else if (m.startsWith("RUN:")) {
+            console.log(chalk.blue(m));
           } else {
-            console.log(`ALERT 🚨 ${m}`);
+            console.log(m);
           }
         });
       };

--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -6,6 +6,7 @@ import { spawn } from "child_process";
 import fs from "fs";
 import path from "path";
 import os from "os";
+import { loadAlerts } from "../schedule/alerts";
 
 export function createScheduleCommand(): Command {
   const scheduleCommand = new Command("schedule");
@@ -23,6 +24,24 @@ export function createScheduleCommand(): Command {
     });
 
   scheduleCommand
+    .command("alert <cron> <cmd...>")
+    .requiredOption("-c, --criteria <criteria>", "Criteria to match")
+    .description("Schedule a command that triggers alerts when output matches criteria")
+    .action((cron: string, cmd: string[], options: { criteria: string }) => {
+      const command = cmd.join(" ");
+      const task = {
+        id: randomUUID(),
+        cron,
+        command,
+        type: "alert" as const,
+        criteria: options.criteria,
+      };
+      addSchedule(task);
+      reloadSchedulers();
+      console.log(chalk.green(`✓ Scheduled alert ${task.id}`));
+    });
+
+  scheduleCommand
     .command("list")
     .description("List scheduled tasks")
     .action(() => {
@@ -32,7 +51,29 @@ export function createScheduleCommand(): Command {
         return;
       }
       console.log(chalk.bold("Scheduled tasks:"));
-      tasks.forEach((t) => console.log(`${t.id}: ${t.cron} -> ${t.command}`));
+      tasks.forEach((t) => {
+        if (t.type === "alert") {
+          console.log(`${t.id}: ${t.cron} -> ${t.command} [alert: ${t.criteria}]`);
+        } else {
+          console.log(`${t.id}: ${t.cron} -> ${t.command}`);
+        }
+      });
+    });
+
+  scheduleCommand
+    .command("alerts")
+    .description("Show triggered alerts")
+    .action(() => {
+      const alerts = loadAlerts();
+      const entries = Object.entries(alerts);
+      if (entries.length === 0) {
+        console.log(chalk.yellow("No alerts triggered"));
+        return;
+      }
+      console.log(chalk.bold("Triggered alerts:"));
+      for (const [, messages] of entries) {
+        messages.forEach((m) => console.log(`ALERT 🚨 ${m}`));
+      }
     });
 
   scheduleCommand

--- a/src/h1dr4/tools.ts
+++ b/src/h1dr4/tools.ts
@@ -341,13 +341,18 @@ const MORPH_EDIT_TOOL: H1dr4Tool = {
 
 // Function to build tools array conditionally
 function buildH1dr4Tools(): H1dr4Tool[] {
-  const tools = [...BASE_H1DR4_TOOLS];
-  
+  let tools = [...BASE_H1DR4_TOOLS];
+
+  // Optionally remove reasoning tool when disabled (e.g., for headless jobs)
+  if (process.env.H1DR4_DISABLE_REASONING === "1") {
+    tools = tools.filter((t) => t.function.name !== "reason");
+  }
+
   // Add Morph Fast Apply tool if API key is available
   if (process.env.MORPH_API_KEY) {
     tools.splice(3, 0, MORPH_EDIT_TOOL); // Insert after str_replace_editor
   }
-  
+
   return tools;
 }
 

--- a/src/hooks/use-input-handler.ts
+++ b/src/hooks/use-input-handler.ts
@@ -76,8 +76,8 @@ export function useInputHandler({
       return true; // Handled
     }
 
-    // Toggle schedule list with Ctrl+Alt+S to avoid accidental activation
-    if (key.ctrl && key.alt && key.name === "s") {
+    // Toggle schedule list with Ctrl+Option+S to avoid accidental activation
+    if (key.ctrl && key.meta && key.name === "s") {
       setShowScheduleList((prev) => !prev);
       return true;
     }

--- a/src/hooks/use-input-handler.ts
+++ b/src/hooks/use-input-handler.ts
@@ -76,8 +76,8 @@ export function useInputHandler({
       return true; // Handled
     }
 
-    // Toggle schedule list with Shift+S
-    if (key.shift && key.name === "s") {
+    // Toggle schedule list with Ctrl+Shift+S to avoid accidental activation
+    if (key.ctrl && key.shift && key.name === "s") {
       setShowScheduleList((prev) => !prev);
       return true;
     }

--- a/src/hooks/use-input-handler.ts
+++ b/src/hooks/use-input-handler.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from "react";
+import { useState, useMemo, useEffect, useRef } from "react";
 import { useInput } from "ink";
 import { H1dr4Agent, ChatEntry } from "../agent/h1dr4-agent";
 import { ConfirmationService } from "../utils/confirmation-service";
@@ -53,6 +53,7 @@ export function useInputHandler({
     const sessionFlags = confirmationService.getSessionFlags();
     return sessionFlags.allOperations;
   });
+  const lastTabTimeRef = useRef(0);
 
   const handleSpecialKey = (key: Key): boolean => {
     // Don't handle input if confirmation dialog is active
@@ -76,10 +77,22 @@ export function useInputHandler({
       return true; // Handled
     }
 
-    // Toggle schedule list with Ctrl+Option+S to avoid accidental activation
-    if (key.ctrl && key.meta && key.name === "s") {
-      setShowScheduleList((prev) => !prev);
-      return true;
+    // Toggle schedule list by pressing Tab twice quickly
+    if (
+      key.tab &&
+      !key.shift &&
+      !key.ctrl &&
+      !key.meta &&
+      !showCommandSuggestions &&
+      !showModelSelection
+    ) {
+      const now = Date.now();
+      if (now - lastTabTimeRef.current < 500) {
+        setShowScheduleList((prev) => !prev);
+        lastTabTimeRef.current = 0;
+        return true;
+      }
+      lastTabTimeRef.current = now;
     }
 
     // Handle escape key for closing menus

--- a/src/hooks/use-input-handler.ts
+++ b/src/hooks/use-input-handler.ts
@@ -47,6 +47,7 @@ export function useInputHandler({
   const [selectedCommandIndex, setSelectedCommandIndex] = useState(0);
   const [showModelSelection, setShowModelSelection] = useState(false);
   const [selectedModelIndex, setSelectedModelIndex] = useState(0);
+  const [showScheduleList, setShowScheduleList] = useState(false);
   const [autoEditEnabled, setAutoEditEnabled] = useState(() => {
     const confirmationService = ConfirmationService.getInstance();
     const sessionFlags = confirmationService.getSessionFlags();
@@ -75,6 +76,12 @@ export function useInputHandler({
       return true; // Handled
     }
 
+    // Toggle schedule list with Shift+S
+    if (key.shift && key.name === "s") {
+      setShowScheduleList((prev) => !prev);
+      return true;
+    }
+
     // Handle escape key for closing menus
     if (key.escape) {
       if (showCommandSuggestions) {
@@ -85,6 +92,10 @@ export function useInputHandler({
       if (showModelSelection) {
         setShowModelSelection(false);
         setSelectedModelIndex(0);
+        return true;
+      }
+      if (showScheduleList) {
+        setShowScheduleList(false);
         return true;
       }
       if (isProcessing || isStreaming) {
@@ -748,5 +759,6 @@ Respond with ONLY the commit message, no additional text.`;
     availableModels,
     agent,
     autoEditEnabled,
+    showScheduleList,
   };
 }

--- a/src/hooks/use-input-handler.ts
+++ b/src/hooks/use-input-handler.ts
@@ -76,8 +76,8 @@ export function useInputHandler({
       return true; // Handled
     }
 
-    // Toggle schedule list with Ctrl+Shift+S to avoid accidental activation
-    if (key.ctrl && key.shift && key.name === "s") {
+    // Toggle schedule list with Ctrl+Alt+S to avoid accidental activation
+    if (key.ctrl && key.alt && key.name === "s") {
       setShowScheduleList((prev) => !prev);
       return true;
     }

--- a/src/hooks/use-input-handler.ts
+++ b/src/hooks/use-input-handler.ts
@@ -95,6 +95,12 @@ export function useInputHandler({
       lastTabTimeRef.current = now;
     }
 
+    // Fallback shortcut: Ctrl+Shift+S to toggle schedule list
+    if (key.ctrl && key.shift && key.name === "s") {
+      setShowScheduleList((prev) => !prev);
+      return true;
+    }
+
     // Handle escape key for closing menus
     if (key.escape) {
       if (showCommandSuggestions) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,34 +11,10 @@ import { ConfirmationService } from "./utils/confirmation-service";
 import { createMCPCommand } from "./commands/mcp";
 import { createRSSCommand } from "./commands/rss";
 import { createScheduleCommand } from "./commands/schedule";
-import { startAllTasks } from "./schedule/runner";
 import type { ChatCompletionMessageParam } from "openai/resources/chat";
-import fs from "fs";
-import path from "path";
-import os from "os";
 
 // Load environment variables
 dotenv.config();
-startAllTasks();
-process.on("SIGUSR1", startAllTasks);
-
-const UI_PID_FILE = path.join(os.homedir(), ".h1dr4", "ui.pid");
-
-function writeUIPid(): void {
-  try {
-    fs.writeFileSync(UI_PID_FILE, String(process.pid));
-  } catch {
-    // ignore
-  }
-}
-
-function removeUIPid(): void {
-  try {
-    fs.unlinkSync(UI_PID_FILE);
-  } catch {
-    // ignore
-  }
-}
 
 // Disable default SIGINT handling to let Ink handle Ctrl+C
 // We'll handle exit through the input system instead
@@ -52,7 +28,6 @@ process.on("SIGTERM", () => {
       // Ignore errors when setting raw mode
     }
   }
-  removeUIPid();
   console.log("\nGracefully shutting down...");
   process.exit(0);
 });
@@ -396,8 +371,6 @@ program
       console.log("🤖 Starting H1dr4 CLI Conversational Assistant...\n");
 
       ensureUserSettingsDirectory();
-      writeUIPid();
-      process.on("exit", removeUIPid);
 
       render(React.createElement(ChatInterface, { agent }));
     } catch (error: any) {

--- a/src/schedule/alerts.ts
+++ b/src/schedule/alerts.ts
@@ -3,7 +3,6 @@ import path from "path";
 import os from "os";
 
 const ALERTS_FILE = path.join(os.homedir(), ".h1dr4", "alerts.json");
-console.log(`Using alert log: ${ALERTS_FILE}`);
 
 interface AlertLog {
   [taskId: string]: string[];
@@ -12,7 +11,10 @@ interface AlertLog {
 function loadAlertLog(): AlertLog {
   try {
     return JSON.parse(fs.readFileSync(ALERTS_FILE, "utf8"));
-  } catch (err) {
+  } catch (err: any) {
+    if (err?.code === "ENOENT") {
+      return {};
+    }
     console.error(`Failed to load alert log at ${ALERTS_FILE}: ${err}`);
     return {};
   }

--- a/src/schedule/alerts.ts
+++ b/src/schedule/alerts.ts
@@ -3,6 +3,7 @@ import path from "path";
 import os from "os";
 
 const ALERTS_FILE = path.join(os.homedir(), ".h1dr4", "alerts.json");
+console.log(`Using alert log: ${ALERTS_FILE}`);
 
 interface AlertLog {
   [taskId: string]: string[];
@@ -11,14 +12,19 @@ interface AlertLog {
 function loadAlertLog(): AlertLog {
   try {
     return JSON.parse(fs.readFileSync(ALERTS_FILE, "utf8"));
-  } catch {
+  } catch (err) {
+    console.error(`Failed to load alert log at ${ALERTS_FILE}: ${err}`);
     return {};
   }
 }
 
 function saveAlertLog(log: AlertLog): void {
-  fs.mkdirSync(path.dirname(ALERTS_FILE), { recursive: true });
-  fs.writeFileSync(ALERTS_FILE, JSON.stringify(log, null, 2));
+  try {
+    fs.mkdirSync(path.dirname(ALERTS_FILE), { recursive: true });
+    fs.writeFileSync(ALERTS_FILE, JSON.stringify(log, null, 2));
+  } catch (err) {
+    console.error(`Failed to save alert log at ${ALERTS_FILE}: ${err}`);
+  }
 }
 
 export function isAlertLogged(taskId: string, message: string): boolean {

--- a/src/schedule/alerts.ts
+++ b/src/schedule/alerts.ts
@@ -1,0 +1,40 @@
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+const ALERTS_FILE = path.join(os.homedir(), ".h1dr4", "alerts.json");
+
+interface AlertLog {
+  [taskId: string]: string[];
+}
+
+function loadAlertLog(): AlertLog {
+  try {
+    return JSON.parse(fs.readFileSync(ALERTS_FILE, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+function saveAlertLog(log: AlertLog): void {
+  fs.mkdirSync(path.dirname(ALERTS_FILE), { recursive: true });
+  fs.writeFileSync(ALERTS_FILE, JSON.stringify(log, null, 2));
+}
+
+export function isAlertLogged(taskId: string, message: string): boolean {
+  const log = loadAlertLog();
+  return log[taskId]?.includes(message) ?? false;
+}
+
+export function logAlert(taskId: string, message: string): void {
+  const log = loadAlertLog();
+  if (!log[taskId]) {
+    log[taskId] = [];
+  }
+  log[taskId].push(message);
+  saveAlertLog(log);
+}
+
+export function loadAlerts(): AlertLog {
+  return loadAlertLog();
+}

--- a/src/schedule/config.ts
+++ b/src/schedule/config.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 import os from "os";
 
-export type ScheduleType = "command" | "alert";
+export type ScheduleType = "command" | "alert" | "alert-exact";
 
 export interface ScheduledTask {
   id: string;

--- a/src/schedule/config.ts
+++ b/src/schedule/config.ts
@@ -10,6 +10,7 @@ export interface ScheduledTask {
   command: string;
   type?: ScheduleType;
   criteria?: string;
+  alertDuration?: number;
 }
 
 const CONFIG_FILE = path.join(os.homedir(), ".h1dr4", "schedules.json");

--- a/src/schedule/config.ts
+++ b/src/schedule/config.ts
@@ -2,10 +2,14 @@ import fs from "fs";
 import path from "path";
 import os from "os";
 
+export type ScheduleType = "command" | "alert";
+
 export interface ScheduledTask {
   id: string;
   cron: string;
   command: string;
+  type?: ScheduleType;
+  criteria?: string;
 }
 
 const CONFIG_FILE = path.join(os.homedir(), ".h1dr4", "schedules.json");

--- a/src/schedule/config.ts
+++ b/src/schedule/config.ts
@@ -23,8 +23,15 @@ export function loadSchedules(): ScheduledTask[] {
 }
 
 export function saveSchedules(tasks: ScheduledTask[]): void {
-  fs.mkdirSync(path.dirname(CONFIG_FILE), { recursive: true });
-  fs.writeFileSync(CONFIG_FILE, JSON.stringify(tasks, null, 2));
+  try {
+    const dir = path.dirname(CONFIG_FILE);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(CONFIG_FILE, JSON.stringify(tasks, null, 2));
+  } catch (error: any) {
+    console.error(
+      `Failed to save schedules to ${CONFIG_FILE}: ${error?.message || error}`
+    );
+  }
 }
 
 export function addSchedule(task: ScheduledTask): void {

--- a/src/schedule/runner.ts
+++ b/src/schedule/runner.ts
@@ -6,6 +6,8 @@ import os from "os";
 import { loadSchedules, ScheduledTask } from "./config";
 import { ConfirmationService } from "../utils/confirmation-service";
 import { isAlertLogged, logAlert } from "./alerts";
+import { getSettingsManager } from "../utils/settings-manager";
+import { H1dr4Client } from "../h1dr4/client";
 
 const CONFIG_FILE = path.join(os.homedir(), ".h1dr4", "schedules.json");
 let watcher: fs.FSWatcher | null = null;
@@ -47,7 +49,7 @@ function spawnInTerminal(command: string): void {
 function runTask(task: ScheduledTask): void {
   const confirmationService = ConfirmationService.getInstance();
   confirmationService.setSessionFlag("allOperations", true);
-  if (task.type === "alert") {
+  if (task.type === "alert" || task.type === "alert-exact") {
     runAlertTask(task);
     return;
   }
@@ -60,14 +62,40 @@ function runTask(task: ScheduledTask): void {
 }
 
 function runAlertTask(task: ScheduledTask): void {
-  exec(task.command, (_error, stdout, stderr) => {
+  exec(task.command, async (_error, stdout, stderr) => {
     const output = (stdout + stderr).trim();
     const criteria = task.criteria || "";
-    if (criteria && output.toLowerCase().includes(criteria.toLowerCase())) {
-      if (!isAlertLogged(task.id, output)) {
+    if (!criteria) {
+      return;
+    }
+
+    if (task.type === "alert-exact") {
+      if (output.toLowerCase().includes(criteria.toLowerCase())) {
+        if (!isAlertLogged(task.id, output)) {
+          logAlert(task.id, output);
+          console.log(`ALERT 🚨 ${output}`);
+        }
+      }
+      return;
+    }
+
+    try {
+      const manager = getSettingsManager();
+      const apiKey = manager.getApiKey();
+      if (!apiKey) {
+        return;
+      }
+      const baseURL = manager.getBaseURL();
+      const model = manager.getCurrentModel();
+      const client = new H1dr4Client(apiKey, model, baseURL);
+      const prompt = `Command output:\n${output}\n\nCriteria:\n${criteria}\n\nDoes the output satisfy the criteria? Respond with YES or NO.`;
+      const response = await client.reason(prompt);
+      if (/^\s*yes\b/i.test(response) && !isAlertLogged(task.id, output)) {
         logAlert(task.id, output);
         console.log(`ALERT 🚨 ${output}`);
       }
+    } catch {
+      // swallow errors to avoid crashing the scheduler
     }
   });
 }

--- a/src/schedule/runner.ts
+++ b/src/schedule/runner.ts
@@ -61,6 +61,13 @@ function runTask(task: ScheduledTask): void {
   }
 }
 
+function spawnAlertWindow(message: string): void {
+  const nodeCmd = `${process.execPath} -e "console.log(${JSON.stringify(
+    "ALERT 🚨 " + message,
+  )}); setInterval(()=>{}, 1e8)"`;
+  spawnInTerminal(nodeCmd);
+}
+
 function runAlertTask(task: ScheduledTask): void {
   const manager = getSettingsManager();
   const apiKey = manager.getApiKey();
@@ -91,13 +98,17 @@ function runAlertTask(task: ScheduledTask): void {
     }
 
     if (task.type === "alert-exact") {
-      if (output.toLowerCase().includes(criteria.toLowerCase())) {
+      let match = false;
+      try {
+        match = new RegExp(criteria, "i").test(output);
+      } catch {
+        match = output.toLowerCase().includes(criteria.toLowerCase());
+      }
+      if (match) {
         if (!isAlertLogged(task.id, output)) {
           logAlert(task.id, output);
           console.log(`ALERT 🚨 ${output}`);
-          const display = output.replace(/\s+/g, " ");
-          const sanitized = display.replace(/"/g, '\\"');
-          spawnInTerminal(`echo \"ALERT 🚨 ${sanitized}\"`);
+          spawnAlertWindow(output);
         }
       } else {
         const message = `NO MATCH: ${output}`;
@@ -121,7 +132,6 @@ function runAlertTask(task: ScheduledTask): void {
       const model = manager.getCurrentModel();
       const client = new H1dr4Client(apiKey, model, baseURL);
 
-      // Use a binary tool so Grok must respond with YES or NO
       const tool: H1dr4Tool = {
         type: "function",
         function: {
@@ -164,9 +174,7 @@ function runAlertTask(task: ScheduledTask): void {
         if (!isAlertLogged(task.id, output)) {
           logAlert(task.id, output);
           console.log(`ALERT 🚨 ${output}`);
-          const display = output.replace(/\s+/g, " ");
-          const sanitized = display.replace(/"/g, '\\"');
-          spawnInTerminal(`echo \"ALERT 🚨 ${sanitized}\"`);
+          spawnAlertWindow(output);
         }
       } else {
         const message = `NO MATCH: ${output}`;

--- a/src/schedule/runner.ts
+++ b/src/schedule/runner.ts
@@ -62,9 +62,10 @@ function runTask(task: ScheduledTask): void {
 }
 
 function spawnAlertWindow(message: string): void {
+  const duration = process.env.H1DR4_ALERT_DURATION || "30000";
   const nodeCmd = `${process.execPath} -e "console.log(${JSON.stringify(
     "ALERT 🚨 " + message,
-  )}); setInterval(()=>{}, 1e8)"`;
+  )}); setTimeout(()=>process.exit(0), ${duration})"`;
   spawnInTerminal(nodeCmd);
 }
 
@@ -75,6 +76,8 @@ function runAlertTask(task: ScheduledTask): void {
   if (apiKey) {
     env.GROK_API_KEY = apiKey;
   }
+  // Disable reasoning tool to avoid restricted endpoint errors in headless mode
+  env.H1DR4_DISABLE_REASONING = "1";
 
   // Log the command execution attempt for troubleshooting
   logAlert(task.id, `RUN: ${task.command}`);

--- a/src/schedule/runner.ts
+++ b/src/schedule/runner.ts
@@ -7,7 +7,7 @@ import { loadSchedules, ScheduledTask } from "./config";
 import { ConfirmationService } from "../utils/confirmation-service";
 import { isAlertLogged, logAlert } from "./alerts";
 import { getSettingsManager } from "../utils/settings-manager";
-import { H1dr4Client } from "../h1dr4/client";
+import { H1dr4Client, H1dr4Tool } from "../h1dr4/client";
 
 const CONFIG_FILE = path.join(os.homedir(), ".h1dr4", "schedules.json");
 let watcher: fs.FSWatcher | null = null;
@@ -112,9 +112,47 @@ function runAlertTask(task: ScheduledTask): void {
       const baseURL = manager.getBaseURL();
       const model = manager.getCurrentModel();
       const client = new H1dr4Client(apiKey, model, baseURL);
-      const prompt = `Command output:\n${output}\n\nCriteria:\n${criteria}\n\nDoes the output satisfy the criteria? Respond with YES or NO.`;
-      const response = await client.reason(prompt);
-      if (/^\s*yes\b/i.test(response)) {
+
+      // Use a binary tool so Grok must respond with YES or NO
+      const tool: H1dr4Tool = {
+        type: "function",
+        function: {
+          name: "alert_match",
+          description: "Return YES if output satisfies the criteria, otherwise NO",
+          parameters: {
+            type: "object",
+            properties: {
+              result: { type: "string", enum: ["YES", "NO"] },
+            },
+            required: ["result"],
+          },
+        },
+      };
+
+      const messages = [
+        {
+          role: "system" as const,
+          content: "Decide if the command output satisfies the criteria by calling the alert_match tool.",
+        },
+        {
+          role: "user" as const,
+          content: `Command output:\n${output}\n\nCriteria:\n${criteria}`,
+        },
+      ];
+
+      const resp = await client.chat(messages, [tool]);
+      const toolCall = resp.choices[0]?.message.tool_calls?.[0];
+      let match = false;
+      if (toolCall) {
+        try {
+          const args = JSON.parse(toolCall.function.arguments);
+          match = args.result === "YES";
+        } catch {
+          match = false;
+        }
+      }
+
+      if (match) {
         if (!isAlertLogged(task.id, output)) {
           logAlert(task.id, output);
           console.log(`ALERT 🚨 ${output}`);

--- a/src/schedule/runner.ts
+++ b/src/schedule/runner.ts
@@ -88,6 +88,9 @@ function runAlertTask(task: ScheduledTask): void {
         if (!isAlertLogged(task.id, output)) {
           logAlert(task.id, output);
           console.log(`ALERT 🚨 ${output}`);
+          const display = output.replace(/\s+/g, " ");
+          const sanitized = display.replace(/"/g, '\\"');
+          spawnInTerminal(`echo \"ALERT 🚨 ${sanitized}\"`);
         }
       } else {
         const message = `NO MATCH: ${output}`;
@@ -156,6 +159,9 @@ function runAlertTask(task: ScheduledTask): void {
         if (!isAlertLogged(task.id, output)) {
           logAlert(task.id, output);
           console.log(`ALERT 🚨 ${output}`);
+          const display = output.replace(/\s+/g, " ");
+          const sanitized = display.replace(/"/g, '\\"');
+          spawnInTerminal(`echo \"ALERT 🚨 ${sanitized}\"`);
         }
       } else {
         const message = `NO MATCH: ${output}`;

--- a/src/schedule/runner.ts
+++ b/src/schedule/runner.ts
@@ -62,10 +62,22 @@ function runTask(task: ScheduledTask): void {
 }
 
 function runAlertTask(task: ScheduledTask): void {
-  exec(task.command, async (_error, stdout, stderr) => {
+  exec(task.command, async (error, stdout, stderr) => {
+    if (error) {
+      const message = `ERROR: ${error.message}`;
+      if (!isAlertLogged(task.id, message)) {
+        logAlert(task.id, message);
+      }
+      return;
+    }
+
     const output = (stdout + stderr).trim();
     const criteria = task.criteria || "";
     if (!criteria) {
+      const message = "ERROR: missing criteria";
+      if (!isAlertLogged(task.id, message)) {
+        logAlert(task.id, message);
+      }
       return;
     }
 
@@ -75,6 +87,11 @@ function runAlertTask(task: ScheduledTask): void {
           logAlert(task.id, output);
           console.log(`ALERT 🚨 ${output}`);
         }
+      } else {
+        const message = `NO MATCH: ${output}`;
+        if (!isAlertLogged(task.id, message)) {
+          logAlert(task.id, message);
+        }
       }
       return;
     }
@@ -83,6 +100,10 @@ function runAlertTask(task: ScheduledTask): void {
       const manager = getSettingsManager();
       const apiKey = manager.getApiKey();
       if (!apiKey) {
+        const message = "ERROR: missing API key";
+        if (!isAlertLogged(task.id, message)) {
+          logAlert(task.id, message);
+        }
         return;
       }
       const baseURL = manager.getBaseURL();
@@ -90,12 +111,22 @@ function runAlertTask(task: ScheduledTask): void {
       const client = new H1dr4Client(apiKey, model, baseURL);
       const prompt = `Command output:\n${output}\n\nCriteria:\n${criteria}\n\nDoes the output satisfy the criteria? Respond with YES or NO.`;
       const response = await client.reason(prompt);
-      if (/^\s*yes\b/i.test(response) && !isAlertLogged(task.id, output)) {
-        logAlert(task.id, output);
-        console.log(`ALERT 🚨 ${output}`);
+      if (/^\s*yes\b/i.test(response)) {
+        if (!isAlertLogged(task.id, output)) {
+          logAlert(task.id, output);
+          console.log(`ALERT 🚨 ${output}`);
+        }
+      } else {
+        const message = `NO MATCH: ${output}`;
+        if (!isAlertLogged(task.id, message)) {
+          logAlert(task.id, message);
+        }
       }
-    } catch {
-      // swallow errors to avoid crashing the scheduler
+    } catch (err: any) {
+      const message = `ERROR: ${err?.message || err}`;
+      if (!isAlertLogged(task.id, message)) {
+        logAlert(task.id, message);
+      }
     }
   });
 }

--- a/src/schedule/runner.ts
+++ b/src/schedule/runner.ts
@@ -62,7 +62,14 @@ function runTask(task: ScheduledTask): void {
 }
 
 function runAlertTask(task: ScheduledTask): void {
-  exec(task.command, async (error, stdout, stderr) => {
+  const manager = getSettingsManager();
+  const apiKey = manager.getApiKey();
+  const env = { ...process.env } as NodeJS.ProcessEnv;
+  if (apiKey) {
+    env.GROK_API_KEY = apiKey;
+  }
+
+  exec(task.command, { env }, async (error, stdout, stderr) => {
     if (error) {
       const message = `ERROR: ${error.message}`;
       if (!isAlertLogged(task.id, message)) {
@@ -103,8 +110,6 @@ function runAlertTask(task: ScheduledTask): void {
     }
 
     try {
-      const manager = getSettingsManager();
-      const apiKey = manager.getApiKey();
       if (!apiKey) {
         const message = "ERROR: missing API key";
         if (!isAlertLogged(task.id, message)) {

--- a/src/schedule/runner.ts
+++ b/src/schedule/runner.ts
@@ -1,10 +1,11 @@
 import schedule from "node-schedule";
-import { spawn } from "child_process";
+import { spawn, exec } from "child_process";
 import fs from "fs";
 import path from "path";
 import os from "os";
 import { loadSchedules, ScheduledTask } from "./config";
 import { ConfirmationService } from "../utils/confirmation-service";
+import { isAlertLogged, logAlert } from "./alerts";
 
 const CONFIG_FILE = path.join(os.homedir(), ".h1dr4", "schedules.json");
 let watcher: fs.FSWatcher | null = null;
@@ -46,10 +47,27 @@ function spawnInTerminal(command: string): void {
 function runTask(task: ScheduledTask): void {
   const confirmationService = ConfirmationService.getInstance();
   confirmationService.setSessionFlag("allOperations", true);
+  if (task.type === "alert") {
+    runAlertTask(task);
+    return;
+  }
   if (process.stdout.isTTY) {
     spawn(task.command, { shell: true, stdio: "inherit" });
   } else {
     // no TTY, open in new terminal
     spawnInTerminal(task.command);
   }
+}
+
+function runAlertTask(task: ScheduledTask): void {
+  exec(task.command, (_error, stdout, stderr) => {
+    const output = (stdout + stderr).trim();
+    const criteria = task.criteria || "";
+    if (criteria && output.toLowerCase().includes(criteria.toLowerCase())) {
+      if (!isAlertLogged(task.id, output)) {
+        logAlert(task.id, output);
+        console.log(`ALERT 🚨 ${output}`);
+      }
+    }
+  });
 }

--- a/src/schedule/runner.ts
+++ b/src/schedule/runner.ts
@@ -61,11 +61,19 @@ function runTask(task: ScheduledTask): void {
   }
 }
 
-function spawnAlertWindow(message: string): void {
-  const duration = process.env.H1DR4_ALERT_DURATION || "30000";
-  const nodeCmd = `${process.execPath} -e "console.log(${JSON.stringify(
-    "ALERT 🚨 " + message,
-  )}); setTimeout(()=>process.exit(0), ${duration})"`;
+function spawnAlertWindow(message: string, duration?: number): void {
+  const dur =
+    typeof duration === "number"
+      ? duration
+      : parseInt(process.env.H1DR4_ALERT_DURATION || "30000", 10);
+  const nodeCmd =
+    dur > 0
+      ? `${process.execPath} -e "console.log(${JSON.stringify(
+          "ALERT 🚨 " + message,
+        )}); setTimeout(()=>process.exit(0), ${dur})"`
+      : `${process.execPath} -e "console.log(${JSON.stringify(
+          "ALERT 🚨 " + message,
+        )}); setInterval(()=>{}, 1e8)"`;
   spawnInTerminal(nodeCmd);
 }
 
@@ -76,8 +84,6 @@ function runAlertTask(task: ScheduledTask): void {
   if (apiKey) {
     env.GROK_API_KEY = apiKey;
   }
-  // Disable reasoning tool to avoid restricted endpoint errors in headless mode
-  env.H1DR4_DISABLE_REASONING = "1";
 
   // Log the command execution attempt for troubleshooting
   logAlert(task.id, `RUN: ${task.command}`);
@@ -106,7 +112,7 @@ function runAlertTask(task: ScheduledTask): void {
         if (!isAlertLogged(task.id, message)) {
           logAlert(task.id, message);
           console.log(`ALERT 🚨 ${output}`);
-          spawnAlertWindow(output);
+          spawnAlertWindow(output, task.alertDuration);
         }
       } else {
         const message = `NO MATCH: ${output}`;
@@ -147,7 +153,7 @@ function runAlertTask(task: ScheduledTask): void {
         if (!isAlertLogged(task.id, message)) {
           logAlert(task.id, message);
           console.log(`ALERT 🚨 ${output}`);
-          spawnAlertWindow(output);
+          spawnAlertWindow(output, task.alertDuration);
         }
       } else {
         const message = `NO MATCH: ${output}`;

--- a/src/schedule/runner.ts
+++ b/src/schedule/runner.ts
@@ -7,7 +7,7 @@ import { loadSchedules, ScheduledTask } from "./config";
 import { ConfirmationService } from "../utils/confirmation-service";
 import { isAlertLogged, logAlert } from "./alerts";
 import { getSettingsManager } from "../utils/settings-manager";
-import { H1dr4Client, H1dr4Tool } from "../h1dr4/client";
+import { H1dr4Client } from "../h1dr4/client";
 
 const CONFIG_FILE = path.join(os.homedir(), ".h1dr4", "schedules.json");
 let watcher: fs.FSWatcher | null = null;
@@ -123,25 +123,11 @@ function runAlertTask(task: ScheduledTask): void {
       const model = manager.getCurrentModel();
       const client = new H1dr4Client(apiKey, model, baseURL);
 
-      const tool: H1dr4Tool = {
-        type: "function",
-        function: {
-          name: "alert_match",
-          description: "Return YES if output satisfies the criteria, otherwise NO",
-          parameters: {
-            type: "object",
-            properties: {
-              result: { type: "string", enum: ["YES", "NO"] },
-            },
-            required: ["result"],
-          },
-        },
-      };
-
       const messages = [
         {
           role: "system" as const,
-          content: "Decide if the command output satisfies the criteria by calling the alert_match tool.",
+          content:
+            "Decide if the command output satisfies the criteria. Respond with YES or NO only.",
         },
         {
           role: "user" as const,
@@ -149,17 +135,9 @@ function runAlertTask(task: ScheduledTask): void {
         },
       ];
 
-      const resp = await client.chat(messages, [tool]);
-      const toolCall = resp.choices[0]?.message.tool_calls?.[0];
-      let match = false;
-      if (toolCall) {
-        try {
-          const args = JSON.parse(toolCall.function.arguments);
-          match = args.result === "YES";
-        } catch {
-          match = false;
-        }
-      }
+      const resp = await client.chat(messages);
+      const reply = resp.choices[0]?.message.content?.trim().toLowerCase();
+      const match = reply === "yes";
 
       if (match) {
         const message = `ALERT: ${output}`;

--- a/src/schedule/runner.ts
+++ b/src/schedule/runner.ts
@@ -76,23 +76,22 @@ function runAlertTask(task: ScheduledTask): void {
     env.GROK_API_KEY = apiKey;
   }
 
+  // Log the command execution attempt for troubleshooting
+  logAlert(task.id, `RUN: ${task.command}`);
+
   exec(task.command, { env }, async (error, stdout, stderr) => {
+    const output = (stdout + stderr).trim();
     if (error) {
-      const message = `ERROR: ${error.message}`;
-      if (!isAlertLogged(task.id, message)) {
-        logAlert(task.id, message);
-      }
+      const message = `ERROR: ${error.message}${output ? `\n${output}` : ""}`;
+      logAlert(task.id, message);
       console.error(message);
       return;
     }
 
-    const output = (stdout + stderr).trim();
     const criteria = task.criteria || "";
     if (!criteria) {
       const message = "ERROR: missing criteria";
-      if (!isAlertLogged(task.id, message)) {
-        logAlert(task.id, message);
-      }
+      logAlert(task.id, message);
       console.error(message);
       return;
     }
@@ -100,16 +99,15 @@ function runAlertTask(task: ScheduledTask): void {
     if (task.type === "alert-exact") {
       const match = output.toLowerCase().includes(criteria.toLowerCase());
       if (match) {
-        if (!isAlertLogged(task.id, output)) {
-          logAlert(task.id, output);
+        const message = `ALERT: ${output}`;
+        if (!isAlertLogged(task.id, message)) {
+          logAlert(task.id, message);
           console.log(`ALERT 🚨 ${output}`);
           spawnAlertWindow(output);
         }
       } else {
         const message = `NO MATCH: ${output}`;
-        if (!isAlertLogged(task.id, message)) {
-          logAlert(task.id, message);
-        }
+        logAlert(task.id, message);
         console.log(message);
       }
       return;
@@ -118,9 +116,7 @@ function runAlertTask(task: ScheduledTask): void {
     try {
       if (!apiKey) {
         const message = "ERROR: missing API key";
-        if (!isAlertLogged(task.id, message)) {
-          logAlert(task.id, message);
-        }
+        logAlert(task.id, message);
         return;
       }
       const baseURL = manager.getBaseURL();
@@ -166,23 +162,20 @@ function runAlertTask(task: ScheduledTask): void {
       }
 
       if (match) {
-        if (!isAlertLogged(task.id, output)) {
-          logAlert(task.id, output);
+        const message = `ALERT: ${output}`;
+        if (!isAlertLogged(task.id, message)) {
+          logAlert(task.id, message);
           console.log(`ALERT 🚨 ${output}`);
           spawnAlertWindow(output);
         }
       } else {
         const message = `NO MATCH: ${output}`;
-        if (!isAlertLogged(task.id, message)) {
-          logAlert(task.id, message);
-        }
+        logAlert(task.id, message);
         console.log(message);
       }
     } catch (err: any) {
       const message = `ERROR: ${err?.message || err}`;
-      if (!isAlertLogged(task.id, message)) {
-        logAlert(task.id, message);
-      }
+      logAlert(task.id, message);
       console.error(message);
     }
   });

--- a/src/schedule/runner.ts
+++ b/src/schedule/runner.ts
@@ -68,6 +68,7 @@ function runAlertTask(task: ScheduledTask): void {
       if (!isAlertLogged(task.id, message)) {
         logAlert(task.id, message);
       }
+      console.error(message);
       return;
     }
 
@@ -78,6 +79,7 @@ function runAlertTask(task: ScheduledTask): void {
       if (!isAlertLogged(task.id, message)) {
         logAlert(task.id, message);
       }
+      console.error(message);
       return;
     }
 
@@ -92,6 +94,7 @@ function runAlertTask(task: ScheduledTask): void {
         if (!isAlertLogged(task.id, message)) {
           logAlert(task.id, message);
         }
+        console.log(message);
       }
       return;
     }
@@ -121,12 +124,14 @@ function runAlertTask(task: ScheduledTask): void {
         if (!isAlertLogged(task.id, message)) {
           logAlert(task.id, message);
         }
+        console.log(message);
       }
     } catch (err: any) {
       const message = `ERROR: ${err?.message || err}`;
       if (!isAlertLogged(task.id, message)) {
         logAlert(task.id, message);
       }
+      console.error(message);
     }
   });
 }

--- a/src/schedule/runner.ts
+++ b/src/schedule/runner.ts
@@ -98,12 +98,7 @@ function runAlertTask(task: ScheduledTask): void {
     }
 
     if (task.type === "alert-exact") {
-      let match = false;
-      try {
-        match = new RegExp(criteria, "i").test(output);
-      } catch {
-        match = output.toLowerCase().includes(criteria.toLowerCase());
-      }
+      const match = output.toLowerCase().includes(criteria.toLowerCase());
       if (match) {
         if (!isAlertLogged(task.id, output)) {
           logAlert(task.id, output);

--- a/src/ui/components/alert-status.tsx
+++ b/src/ui/components/alert-status.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from "react";
+import { Text } from "ink";
+import { loadAlerts } from "../../schedule/alerts";
+
+function countAlerts(): number {
+  try {
+    const alerts = loadAlerts();
+    let total = 0;
+    for (const msgs of Object.values(alerts)) {
+      total += msgs.filter(
+        (m) => !m.startsWith("ERROR:") && !m.startsWith("NO MATCH:")
+      ).length;
+    }
+    return total;
+  } catch {
+    return 0;
+  }
+}
+
+export function AlertStatus(): JSX.Element {
+  const [count, setCount] = useState(() => countAlerts());
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setCount(countAlerts());
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return <Text color="red">🚨 {count}</Text>;
+}
+
+export default AlertStatus;

--- a/src/ui/components/chat-interface.tsx
+++ b/src/ui/components/chat-interface.tsx
@@ -10,6 +10,7 @@ import { ChatInput } from "./chat-input";
 import { MCPStatus } from "./mcp-status";
 import ConfirmationDialog from "./confirmation-dialog";
 import { ScheduleStatus } from "./schedule-status";
+import { AlertStatus } from "./alert-status";
 import { ScheduleList } from "./schedule-list";
 import {
   ConfirmationService,
@@ -243,6 +244,9 @@ function ChatInterfaceWithAgent({ agent }: { agent: H1dr4Agent }) {
             <MCPStatus />
             <Box marginLeft={2}>
               <ScheduleStatus />
+            </Box>
+            <Box marginLeft={2}>
+              <AlertStatus />
             </Box>
           </Box>
 

--- a/src/ui/components/chat-interface.tsx
+++ b/src/ui/components/chat-interface.tsx
@@ -9,6 +9,8 @@ import { ChatHistory } from "./chat-history";
 import { ChatInput } from "./chat-input";
 import { MCPStatus } from "./mcp-status";
 import ConfirmationDialog from "./confirmation-dialog";
+import { ScheduleStatus } from "./schedule-status";
+import { ScheduleList } from "./schedule-list";
 import {
   ConfirmationService,
   ConfirmationOptions,
@@ -44,6 +46,7 @@ function ChatInterfaceWithAgent({ agent }: { agent: H1dr4Agent }) {
     commandSuggestions,
     availableModels,
     autoEditEnabled,
+    showScheduleList,
   } = useInputHandler({
     agent,
     chatHistory,
@@ -238,6 +241,9 @@ function ChatInterfaceWithAgent({ agent }: { agent: H1dr4Agent }) {
               <Text color="yellow">≋ {agent.getCurrentModel()}</Text>
             </Box>
             <MCPStatus />
+            <Box marginLeft={2}>
+              <ScheduleStatus />
+            </Box>
           </Box>
 
           <CommandSuggestions
@@ -253,6 +259,7 @@ function ChatInterfaceWithAgent({ agent }: { agent: H1dr4Agent }) {
             isVisible={showModelSelection}
             currentModel={agent.getCurrentModel()}
           />
+          <ScheduleList isVisible={showScheduleList} />
         </>
       )}
     </Box>

--- a/src/ui/components/schedule-list.tsx
+++ b/src/ui/components/schedule-list.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { Box, Text } from "ink";
+import { loadSchedules } from "../../schedule/config";
+
+interface Props {
+  isVisible: boolean;
+}
+
+export function ScheduleList({ isVisible }: Props): JSX.Element | null {
+  if (!isVisible) return null;
+  const tasks = loadSchedules();
+  return (
+    <Box flexDirection="column" borderStyle="round" borderColor="cyan" padding={1} marginTop={1}>
+      <Text color="cyan" bold>
+        Scheduled tasks
+      </Text>
+      {tasks.length === 0 ? (
+        <Text>No tasks scheduled</Text>
+      ) : (
+        tasks.map((t) => (
+          <Text key={t.id}>
+            {`${t.id}: ${t.cron} -> ${t.command}${t.type ? ` [${t.type}${t.criteria ? `: ${t.criteria}` : ""}]` : ""}`}
+          </Text>
+        ))
+      )}
+    </Box>
+  );
+}

--- a/src/ui/components/schedule-status.tsx
+++ b/src/ui/components/schedule-status.tsx
@@ -1,0 +1,20 @@
+import React, { useEffect, useState } from "react";
+import { Text } from "ink";
+import { loadSchedules } from "../../schedule/config";
+
+export function ScheduleStatus(): JSX.Element {
+  const [count, setCount] = useState(() => loadSchedules().length);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      try {
+        setCount(loadSchedules().length);
+      } catch {
+        // ignore
+      }
+    }, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return <Text color="green">⏰ {count}</Text>;
+}


### PR DESCRIPTION
## Summary
- extend scheduler to support alert tasks with criteria-based evaluation
- log triggered alerts and prevent duplicates
- add CLI commands for scheduling and viewing alerts

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba1fcbfb10832ca1a8eccb40ad060c