### PR TITLE
feat: add configurable alert monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,12 @@ h1dr4 rss remove myfeed
 # Schedule a command using cron syntax
 h1dr4 schedule add "0 9 * * 1" "echo 'weekly task'"
 
+# Notify when the command finishes
+h1dr4 schedule add --notify "0 9 * * 1" "h1dr4 -p 'run daily report'"
+
+# Alert only when output matches text
+h1dr4 schedule add --criteria "success" "0 * * * *" "./script.sh"
+
 # List scheduled tasks
 h1dr4 schedule list
 
@@ -457,9 +463,11 @@ h1dr4 schedule remove TASK_ID
 ```
 
 Scheduled tasks run even if the CLI is closed. A background daemon watches
-`~/.h1dr4/schedules.json` and launches the command at the specified time. If the
-chat interface is open, output is printed directly in the terminal. Otherwise,
-the daemon attempts to open a new terminal window to execute the command.
+`~/.h1dr4/schedules.json` and launches the command at the specified time.
+Use `--notify` to always pop up a terminal with the command output, or
+`--criteria` to alert only when the output contains a specific string.
+Commands may include programmatic prompts via `h1dr4 -p "<prompt>"` to run
+the CLI headlessly.
 
 ### Alert Monitoring
 
@@ -469,6 +477,9 @@ specific keyword or phrase.
 ```bash
 # Alert every minute if latest news mentions "trump"
 h1dr4 alert add "* * * * *" "trump" "h1dr4 news latest"
+
+# Alerts can also run programmatic prompts
+h1dr4 alert add "*/10 * * * *" "passed" "h1dr4 -p 'npm test'"
 
 # List configured alerts
 h1dr4 alert list

--- a/README.md
+++ b/README.md
@@ -455,6 +455,9 @@ h1dr4 schedule add --notify "0 9 * * 1" "h1dr4 -p 'run daily report'"
 # Alert only when output matches text
 h1dr4 schedule add --criteria "success" "0 * * * *" "./script.sh"
 
+# Limit tool usage for a headless prompt
+h1dr4 schedule add "0 * * * *" "h1dr4 --max-tool-rounds 25 -p 'status check'"
+
 # List scheduled tasks
 h1dr4 schedule list
 
@@ -466,8 +469,8 @@ Scheduled tasks run even if the CLI is closed. A background daemon watches
 `~/.h1dr4/schedules.json` and launches the command at the specified time.
 Use `--notify` to always pop up a terminal with the command output, or
 `--criteria` to alert only when the output contains a specific string.
-Commands may include programmatic prompts via `h1dr4 -p "<prompt>"` to run
-the CLI headlessly.
+Commands may include programmatic prompts like `h1dr4 -p "<prompt>"` and can
+limit tool usage with `--max-tool-rounds` to run the CLI headlessly.
 
 ### Alert Monitoring
 
@@ -479,7 +482,7 @@ specific keyword or phrase.
 h1dr4 alert add "* * * * *" "trump" "h1dr4 news latest"
 
 # Alerts can also run programmatic prompts
-h1dr4 alert add "*/10 * * * *" "passed" "h1dr4 -p 'npm test'"
+h1dr4 alert add "*/10 * * * *" "passed" "h1dr4 --max-tool-rounds 20 -p 'npm test'"
 
 # List configured alerts
 h1dr4 alert list
@@ -492,8 +495,10 @@ h1dr4 alert history
 ```
 
 Alerts are stored in `~/.h1dr4/alerts.json` and continue running in the
-background similar to scheduled tasks. When a match occurs, a new terminal
-window displays the alert details so you don't miss the event.
+background similar to scheduled tasks. Commands may include headless prompts
+like `h1dr4 -p "<prompt>"` and can constrain tool usage with
+`--max-tool-rounds`. When a match occurs, a new terminal window displays the
+alert details so you don't miss the event.
 
 ### Managing MCP Servers
 

--- a/README.md
+++ b/README.md
@@ -461,6 +461,28 @@ Scheduled tasks run even if the CLI is closed. A background daemon watches
 chat interface is open, output is printed directly in the terminal. Otherwise,
 the daemon attempts to open a new terminal window to execute the command.
 
+### Alert Monitoring
+
+Alerts periodically run a command and notify you when its output contains a
+specific keyword or phrase.
+
+```bash
+# Alert every minute if latest news mentions "trump"
+h1dr4 alert add "* * * * *" "trump" "h1dr4 news latest"
+
+# List configured alerts
+h1dr4 alert list
+
+# Remove an alert
+h1dr4 alert remove ALERT_ID
+
+# View triggered alert events
+h1dr4 alert history
+```
+
+Alerts are stored in `~/.h1dr4/alerts.json` and continue running in the
+background similar to scheduled tasks.
+
 ### Managing MCP Servers
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -481,7 +481,8 @@ h1dr4 alert history
 ```
 
 Alerts are stored in `~/.h1dr4/alerts.json` and continue running in the
-background similar to scheduled tasks.
+background similar to scheduled tasks. When a match occurs, a new terminal
+window displays the alert details so you don't miss the event.
 
 ### Managing MCP Servers
 

--- a/src/agent/h1dr4-agent.ts
+++ b/src/agent/h1dr4-agent.ts
@@ -162,8 +162,14 @@ TASK PLANNING WITH TODO LISTS:
 - Todo lists provide visual feedback with colors: ✅ Green (completed), 🔄 Cyan (in progress), ⏳ Yellow (pending)
 - Always create todos with priorities: 'high' (🔴), 'medium' (🟡), 'low' (🟢)
 
+PROGRAMMATIC CLI:
+- Run single prompts non-interactively with \`h1dr4 -p "<prompt>"\`
+- Useful for scripting, scheduled tasks, and alerts
+
 SCHEDULING TASKS:
-- Schedule shell commands with \`h1dr4 schedule add "<cron>" "<command>"\`
+- Schedule shell commands with \`h1dr4 schedule add [--notify] [--criteria "<text>"] "<cron>" "<command>"\`
+- Include \`--notify\` to show output when the command finishes or \`--criteria\` to alert only on matches
+- Commands can include \`h1dr4 -p "<prompt>"\` for programmatic tasks
 - Use \`h1dr4 schedule list\` to view existing tasks
 - Use \`h1dr4 schedule remove <id>\` to cancel a task; to modify one, remove it and add a new entry
 - Tasks are stored in \`~/.h1dr4/schedules.json\`, run automatically when due, and bypass confirmation
@@ -175,6 +181,7 @@ ALERT MONITORING:
 - Use \`h1dr4 alert remove <id>\` to delete an alert
 - Use \`h1dr4 alert history\` to view triggered alert events
 - Alerts are stored in \`~/.h1dr4/alerts.json\` and continue running in the background like scheduled tasks
+- Commands can include \`h1dr4 -p "<prompt>"\` to run prompts headlessly
 
 USER CONFIRMATION SYSTEM:
 File operations (create_file, str_replace_editor) and bash commands will automatically request user confirmation before execution. The confirmation system will show users the actual content or command before they decide. Users can choose to approve individual operations or approve all operations of that type for the session.

--- a/src/agent/h1dr4-agent.ts
+++ b/src/agent/h1dr4-agent.ts
@@ -168,6 +168,14 @@ SCHEDULING TASKS:
 - Use \`h1dr4 schedule remove <id>\` to cancel a task; to modify one, remove it and add a new entry
 - Tasks are stored in \`~/.h1dr4/schedules.json\`, run automatically when due, and bypass confirmation
 
+ALERT MONITORING:
+- Create alerts that run commands on a schedule and trigger when output matches specific text
+- Use \`h1dr4 alert add "<cron>" "<criteria>" "<command>"\` to add an alert
+- Use \`h1dr4 alert list\` to view existing alerts
+- Use \`h1dr4 alert remove <id>\` to delete an alert
+- Use \`h1dr4 alert history\` to view triggered alert events
+- Alerts are stored in \`~/.h1dr4/alerts.json\` and continue running in the background like scheduled tasks
+
 USER CONFIRMATION SYSTEM:
 File operations (create_file, str_replace_editor) and bash commands will automatically request user confirmation before execution. The confirmation system will show users the actual content or command before they decide. Users can choose to approve individual operations or approve all operations of that type for the session.
 

--- a/src/agent/h1dr4-agent.ts
+++ b/src/agent/h1dr4-agent.ts
@@ -163,13 +163,14 @@ TASK PLANNING WITH TODO LISTS:
 - Always create todos with priorities: 'high' (🔴), 'medium' (🟡), 'low' (🟢)
 
 PROGRAMMATIC CLI:
-- Run single prompts non-interactively with \`h1dr4 -p "<prompt>"\`
-- Useful for scripting, scheduled tasks, and alerts
+- Run single prompts non-interactively with \`h1dr4 --prompt "<text>"\` or \`h1dr4 -p "<text>"\`
+- Control tool usage with \`--max-tool-rounds <n>\` (default 400)
+- Embed these commands inside schedules or alerts for automation
 
 SCHEDULING TASKS:
 - Schedule shell commands with \`h1dr4 schedule add [--notify] [--criteria "<text>"] "<cron>" "<command>"\`
 - Include \`--notify\` to show output when the command finishes or \`--criteria\` to alert only on matches
-- Commands can include \`h1dr4 -p "<prompt>"\` for programmatic tasks
+- Commands can include \`h1dr4 -p "<prompt>" [--max-tool-rounds <n>]\` for programmatic tasks
 - Use \`h1dr4 schedule list\` to view existing tasks
 - Use \`h1dr4 schedule remove <id>\` to cancel a task; to modify one, remove it and add a new entry
 - Tasks are stored in \`~/.h1dr4/schedules.json\`, run automatically when due, and bypass confirmation
@@ -181,7 +182,7 @@ ALERT MONITORING:
 - Use \`h1dr4 alert remove <id>\` to delete an alert
 - Use \`h1dr4 alert history\` to view triggered alert events
 - Alerts are stored in \`~/.h1dr4/alerts.json\` and continue running in the background like scheduled tasks
-- Commands can include \`h1dr4 -p "<prompt>"\` to run prompts headlessly
+- Commands can include \`h1dr4 -p "<prompt>" [--max-tool-rounds <n>]\` to run prompts headlessly
 
 USER CONFIRMATION SYSTEM:
 File operations (create_file, str_replace_editor) and bash commands will automatically request user confirmation before execution. The confirmation system will show users the actual content or command before they decide. Users can choose to approve individual operations or approve all operations of that type for the session.

--- a/src/alerts/config.ts
+++ b/src/alerts/config.ts
@@ -1,0 +1,58 @@
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+export interface AlertTask {
+  id: string;
+  cron: string;
+  command: string;
+  criteria: string;
+}
+
+export interface AlertEvent {
+  id: string;
+  timestamp: string;
+  output: string;
+}
+
+const ALERTS_FILE = path.join(os.homedir(), ".h1dr4", "alerts.json");
+const EVENTS_FILE = path.join(os.homedir(), ".h1dr4", "alert-events.json");
+
+export function loadAlerts(): AlertTask[] {
+  try {
+    return JSON.parse(fs.readFileSync(ALERTS_FILE, "utf8"));
+  } catch {
+    return [];
+  }
+}
+
+export function saveAlerts(alerts: AlertTask[]): void {
+  fs.mkdirSync(path.dirname(ALERTS_FILE), { recursive: true });
+  fs.writeFileSync(ALERTS_FILE, JSON.stringify(alerts, null, 2));
+}
+
+export function addAlert(alert: AlertTask): void {
+  const alerts = loadAlerts();
+  alerts.push(alert);
+  saveAlerts(alerts);
+}
+
+export function removeAlert(id: string): void {
+  const alerts = loadAlerts().filter((a) => a.id !== id);
+  saveAlerts(alerts);
+}
+
+export function loadAlertEvents(): AlertEvent[] {
+  try {
+    return JSON.parse(fs.readFileSync(EVENTS_FILE, "utf8"));
+  } catch {
+    return [];
+  }
+}
+
+export function addAlertEvent(event: AlertEvent): void {
+  const events = loadAlertEvents();
+  events.push(event);
+  fs.mkdirSync(path.dirname(EVENTS_FILE), { recursive: true });
+  fs.writeFileSync(EVENTS_FILE, JSON.stringify(events, null, 2));
+}

--- a/src/alerts/config.ts
+++ b/src/alerts/config.ts
@@ -20,7 +20,8 @@ const EVENTS_FILE = path.join(os.homedir(), ".h1dr4", "alert-events.json");
 
 export function loadAlerts(): AlertTask[] {
   try {
-    return JSON.parse(fs.readFileSync(ALERTS_FILE, "utf8"));
+    const data = JSON.parse(fs.readFileSync(ALERTS_FILE, "utf8"));
+    return Array.isArray(data) ? data : [];
   } catch {
     return [];
   }
@@ -44,7 +45,8 @@ export function removeAlert(id: string): void {
 
 export function loadAlertEvents(): AlertEvent[] {
   try {
-    return JSON.parse(fs.readFileSync(EVENTS_FILE, "utf8"));
+    const data = JSON.parse(fs.readFileSync(EVENTS_FILE, "utf8"));
+    return Array.isArray(data) ? data : [];
   } catch {
     return [];
   }

--- a/src/alerts/daemon.ts
+++ b/src/alerts/daemon.ts
@@ -1,0 +1,43 @@
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { startAllAlerts } from "./runner";
+
+const CONFIG_FILE = path.join(os.homedir(), ".h1dr4", "alerts.json");
+const PID_FILE = path.join(os.homedir(), ".h1dr4", "alerts.pid");
+
+function writePid() {
+  try {
+    fs.writeFileSync(PID_FILE, String(process.pid));
+  } catch {
+    // ignore
+  }
+}
+
+function removePid() {
+  try {
+    fs.unlinkSync(PID_FILE);
+  } catch {
+    // ignore
+  }
+}
+
+writePid();
+startAllAlerts();
+
+try {
+  fs.watch(CONFIG_FILE, () => {
+    startAllAlerts();
+  });
+} catch {
+  // ignore watch errors
+}
+
+process.on("SIGUSR2", startAllAlerts);
+process.on("exit", removePid);
+process.on("SIGINT", () => {
+  removePid();
+  process.exit(0);
+});
+
+setInterval(() => {}, 1 << 30);

--- a/src/alerts/runner.ts
+++ b/src/alerts/runner.ts
@@ -1,0 +1,67 @@
+import schedule from "node-schedule";
+import { exec } from "child_process";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import chalk from "chalk";
+import { loadAlerts, AlertTask, addAlertEvent } from "./config";
+import { ConfirmationService } from "../utils/confirmation-service";
+
+const CONFIG_FILE = path.join(os.homedir(), ".h1dr4", "alerts.json");
+let watcher: fs.FSWatcher | null = null;
+let jobs: Record<string, any> = {};
+
+export function startAllAlerts(): void {
+  const alerts = loadAlerts();
+  for (const job of Object.values(jobs)) {
+    job.cancel();
+  }
+  jobs = {};
+  for (const alert of alerts) {
+    jobs[alert.id] = schedule.scheduleJob(alert.cron, () => runAlert(alert));
+  }
+  if (!watcher) {
+    const dir = path.dirname(CONFIG_FILE);
+    fs.mkdirSync(dir, { recursive: true });
+    watcher = fs.watch(dir, (_event, filename) => {
+      if (filename === path.basename(CONFIG_FILE)) {
+        startAllAlerts();
+      }
+    });
+  }
+}
+
+function runAlert(alert: AlertTask): void {
+  exec(alert.command, { encoding: "utf8" }, (error, stdout, stderr) => {
+    const output = `${stdout}${stderr}`;
+    if (output.includes(alert.criteria)) {
+      addAlertEvent({ id: alert.id, timestamp: new Date().toISOString(), output });
+      notify(alert, output);
+    }
+  });
+}
+
+function spawnInTerminal(message: string): void {
+  const platform = process.platform;
+  if (platform === "win32") {
+    exec(`start cmd /k "echo ${message}"`);
+  } else if (platform === "darwin") {
+    const osa = `tell application \"Terminal\" to do script \"echo ${message.replace(/"/g, '\\"')}\"`;
+    exec(`osascript -e "${osa}"`);
+  } else {
+    const term = process.env.TERM_PROGRAM || "x-terminal-emulator";
+    exec(`${term} -e 'echo ${message}; read'`);
+  }
+}
+
+function notify(alert: AlertTask, output: string): void {
+  const confirmationService = ConfirmationService.getInstance();
+  confirmationService.setSessionFlag("allOperations", true);
+  const message = `ALERT ${alert.id} triggered (criteria: ${alert.criteria})`;
+  if (process.stdout.isTTY) {
+    console.log(chalk.red(`\n${message}\n`));
+    console.log(output);
+  } else {
+    spawnInTerminal(message);
+  }
+}

--- a/src/alerts/runner.ts
+++ b/src/alerts/runner.ts
@@ -1,5 +1,5 @@
 import schedule from "node-schedule";
-import { exec } from "child_process";
+import { exec, spawn } from "child_process";
 import fs from "fs";
 import path from "path";
 import os from "os";
@@ -48,16 +48,28 @@ function runAlert(alert: AlertTask): void {
 
 function spawnInTerminal(message: string): void {
   const platform = process.platform;
+
+  const hereDoc = (content: string): string => {
+    const token = `EOF_${Math.random().toString(16).slice(2)}`;
+    return `cat <<'${token}'\n${content}\n${token}\nread`;
+  };
+
+  const script = hereDoc(message);
+
   if (platform === "win32") {
-    exec(`start cmd /k "echo ${message} && pause"`);
+    const escaped = script.replace(/"/g, '""');
+    const cmd = `start cmd /k "${escaped}"`;
+    spawn("cmd", ["/c", cmd], { detached: true, stdio: "ignore" }).unref();
   } else if (platform === "darwin") {
-    const escaped = message.replace(/(["\\])/g, "\\$1");
-    const osa = `tell application "Terminal" to do script "echo ${escaped}; read"`;
-    exec(`osascript -e '${osa}'`);
+    const escaped = script.replace(/(["\\])/g, "\\$1");
+    const osa = `tell application "Terminal" to do script \"${escaped}\"`;
+    spawn("osascript", ["-e", osa], { detached: true, stdio: "ignore" }).unref();
   } else {
     const term = process.env.TERM_PROGRAM || "x-terminal-emulator";
-    const escaped = message.replace(/'/g, "'\\''");
-    exec(`${term} -e 'echo ${escaped}; read'`);
+    spawn(term, ["-e", "bash", "-lc", script], {
+      detached: true,
+      stdio: "ignore",
+    }).unref();
   }
 }
 

--- a/src/alerts/runner.ts
+++ b/src/alerts/runner.ts
@@ -10,6 +10,7 @@ import { ConfirmationService } from "../utils/confirmation-service";
 const CONFIG_FILE = path.join(os.homedir(), ".h1dr4", "alerts.json");
 let watcher: fs.FSWatcher | null = null;
 let jobs: Record<string, any> = {};
+const activeNotifications = new Set<string>();
 
 export function startAllAlerts(): void {
   const alerts = loadAlerts();
@@ -32,10 +33,14 @@ export function startAllAlerts(): void {
 }
 
 function runAlert(alert: AlertTask): void {
-  exec(alert.command, { encoding: "utf8" }, (error, stdout, stderr) => {
+  exec(alert.command, { encoding: "utf8" }, (_error, stdout, stderr) => {
     const output = `${stdout}${stderr}`;
     if (output.includes(alert.criteria)) {
-      addAlertEvent({ id: alert.id, timestamp: new Date().toISOString(), output });
+      addAlertEvent({
+        id: alert.id,
+        timestamp: new Date().toISOString(),
+        output,
+      });
       notify(alert, output);
     }
   });
@@ -44,24 +49,33 @@ function runAlert(alert: AlertTask): void {
 function spawnInTerminal(message: string): void {
   const platform = process.platform;
   if (platform === "win32") {
-    exec(`start cmd /k "echo ${message}"`);
+    exec(`start cmd /k "echo ${message} && pause"`);
   } else if (platform === "darwin") {
-    const osa = `tell application \"Terminal\" to do script \"echo ${message.replace(/"/g, '\\"')}\"`;
-    exec(`osascript -e "${osa}"`);
+    const escaped = message.replace(/(["\\])/g, "\\$1");
+    const osa = `tell application "Terminal" to do script "echo ${escaped}; read"`;
+    exec(`osascript -e '${osa}'`);
   } else {
     const term = process.env.TERM_PROGRAM || "x-terminal-emulator";
-    exec(`${term} -e 'echo ${message}; read'`);
+    const escaped = message.replace(/'/g, "'\\''");
+    exec(`${term} -e 'echo ${escaped}; read'`);
   }
 }
 
 function notify(alert: AlertTask, output: string): void {
+  if (activeNotifications.has(alert.id)) {
+    return;
+  }
+  activeNotifications.add(alert.id);
+
   const confirmationService = ConfirmationService.getInstance();
   confirmationService.setSessionFlag("allOperations", true);
   const message = `ALERT ${alert.id} triggered (criteria: ${alert.criteria})`;
+  const fullMessage = `${message}\n${output}`;
+
+  spawnInTerminal(fullMessage);
   if (process.stdout.isTTY) {
-    console.log(chalk.red(`\n${message}\n`));
-    console.log(output);
-  } else {
-    spawnInTerminal(message);
+    console.log(chalk.red(`\n${fullMessage}\n`));
   }
+
+  setTimeout(() => activeNotifications.delete(alert.id), 1000);
 }

--- a/src/commands/alert.ts
+++ b/src/commands/alert.ts
@@ -16,7 +16,7 @@ export function createAlertCommand(): Command {
   alertCommand
     .command("add <cron> <criteria> <cmd...>")
     .description(
-      "Add an alert with cron schedule, match text, and command to run"
+      "Add an alert with cron schedule, match text, and shell command to run. Commands may include headless prompts via `h1dr4 -p`/`--prompt` and options like `--max-tool-rounds`"
     )
     .action((cron: string, criteria: string, cmd: string[]) => {
       const command = cmd.join(" ");
@@ -67,7 +67,7 @@ export function createAlertCommand(): Command {
 
   alertCommand.addHelpText(
     "after",
-    `\nExamples:\n  # alert if latest news mentions trump\n  h1dr4 alert add "* * * * *" "trump" "h1dr4 news latest"\n  \n  # list configured alerts\n  h1dr4 alert list\n  \n  # show triggered events\n  h1dr4 alert history\n`
+    `\nExamples:\n  # alert if latest news mentions trump\n  h1dr4 alert add "* * * * *" "trump" "h1dr4 news latest"\n\n  # run a headless prompt every 10 minutes and alert when output contains 'passed'\n  h1dr4 alert add "*/10 * * * *" "passed" "h1dr4 --max-tool-rounds 20 -p 'npm test'"\n\n  # list configured alerts\n  h1dr4 alert list\n\n  # show triggered events\n  h1dr4 alert history\n`
   );
 
   return alertCommand;

--- a/src/commands/alert.ts
+++ b/src/commands/alert.ts
@@ -1,0 +1,113 @@
+import { Command } from "commander";
+import chalk from "chalk";
+import { addAlert, loadAlerts, removeAlert, loadAlertEvents } from "../alerts/config";
+import { randomUUID } from "crypto";
+import { spawn } from "child_process";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+export function createAlertCommand(): Command {
+  const alertCommand = new Command("alert");
+  alertCommand.description(
+    "Manage alerts that run commands on a schedule and trigger when output matches criteria"
+  );
+
+  alertCommand
+    .command("add <cron> <criteria> <cmd...>")
+    .description(
+      "Add an alert with cron schedule, match text, and command to run"
+    )
+    .action((cron: string, criteria: string, cmd: string[]) => {
+      const command = cmd.join(" ");
+      const alert = { id: randomUUID(), cron, command, criteria };
+      addAlert(alert);
+      reloadAlerts();
+      console.log(chalk.green(`✓ Alert ${alert.id} added`));
+    });
+
+  alertCommand
+    .command("list")
+    .description("List configured alerts")
+    .action(() => {
+      const alerts = loadAlerts();
+      if (alerts.length === 0) {
+        console.log(chalk.yellow("No alerts configured"));
+        return;
+      }
+      console.log(chalk.bold("Alerts:"));
+      alerts.forEach((a) =>
+        console.log(`${a.id}: ${a.cron} -> ${a.command} [${a.criteria}]`)
+      );
+    });
+
+  alertCommand
+    .command("remove <id>")
+    .description("Remove an alert")
+    .action((id: string) => {
+      removeAlert(id);
+      reloadAlerts();
+      console.log(chalk.green(`✓ Removed alert ${id}`));
+    });
+
+  alertCommand
+    .command("history")
+    .description("Show triggered alert events")
+    .action(() => {
+      const events = loadAlertEvents();
+      if (events.length === 0) {
+        console.log(chalk.yellow("No alert events"));
+        return;
+      }
+      console.log(chalk.bold("Alert events:"));
+      events.forEach((e) =>
+        console.log(`${e.timestamp} - ${e.id}\n${e.output}\n`)
+      );
+    });
+
+  alertCommand.addHelpText(
+    "after",
+    `\nExamples:\n  # alert if latest news mentions trump\n  h1dr4 alert add "* * * * *" "trump" "h1dr4 news latest"\n  \n  # list configured alerts\n  h1dr4 alert list\n  \n  # show triggered events\n  h1dr4 alert history\n`
+  );
+
+  return alertCommand;
+}
+
+const PID_FILE = path.join(os.homedir(), ".h1dr4", "alerts.pid");
+const UI_PID_FILE = path.join(os.homedir(), ".h1dr4", "ui.pid");
+const DAEMON_PATH = path.join(__dirname, "../alerts/daemon.js");
+
+function reloadAlerts(): void {
+  let notified = false;
+  try {
+    const uiPid = parseInt(fs.readFileSync(UI_PID_FILE, "utf8"), 10);
+    process.kill(uiPid, "SIGUSR2");
+    notified = true;
+  } catch {}
+  try {
+    const pid = parseInt(fs.readFileSync(PID_FILE, "utf8"), 10);
+    process.kill(pid, "SIGUSR2");
+    notified = true;
+  } catch {}
+  if (!notified) {
+    ensureDaemonRunning();
+  }
+}
+
+function ensureDaemonRunning(): void {
+  try {
+    const uiPid = parseInt(fs.readFileSync(UI_PID_FILE, "utf8"), 10);
+    process.kill(uiPid, 0);
+    return;
+  } catch {}
+  try {
+    const pid = parseInt(fs.readFileSync(PID_FILE, "utf8"), 10);
+    process.kill(pid, 0);
+    return;
+  } catch {}
+  const child = spawn(process.execPath, [DAEMON_PATH], {
+    detached: true,
+    stdio: "ignore",
+  });
+  child.unref();
+}

--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -14,7 +14,7 @@ export function createScheduleCommand(): Command {
   scheduleCommand
     .command("add <cron> <cmd...>")
     .description(
-      "Schedule a command using a cron expression. Optionally notify on completion or only when output matches criteria"
+      "Schedule a command using a cron expression. Optionally notify on completion or only when output matches criteria. Commands may include headless prompts via `h1dr4 -p`/`--prompt` and `--max-tool-rounds`"
     )
     .option("-n, --notify", "Show a notification when the command finishes")
     .option("-c, --criteria <text>", "Alert only when command output contains text")
@@ -62,6 +62,11 @@ export function createScheduleCommand(): Command {
       reloadSchedulers();
       console.log(chalk.green(`✓ Removed task ${id}`));
     });
+  
+  scheduleCommand.addHelpText(
+    "after",
+    `\nExamples:\n  # weekly summary every Monday at 9am\n  h1dr4 schedule add "0 9 * * 1" "h1dr4 -p 'run weekly summary'"\n\n  # alert when a script output contains success and show a popup\n  h1dr4 schedule add --notify --criteria "success" "*/30 * * * *" "./script.sh"\n\n  # limit tool rounds for a headless prompt\n  h1dr4 schedule add "0 * * * *" "h1dr4 --max-tool-rounds 25 -p 'check status'"\n`
+  );
 
   return scheduleCommand;
 }

--- a/src/commands/schedule.ts
+++ b/src/commands/schedule.ts
@@ -13,10 +13,20 @@ export function createScheduleCommand(): Command {
 
   scheduleCommand
     .command("add <cron> <cmd...>")
-    .description("Schedule a command using a cron expression")
-    .action((cron: string, cmd: string[]) => {
+    .description(
+      "Schedule a command using a cron expression. Optionally notify on completion or only when output matches criteria"
+    )
+    .option("-n, --notify", "Show a notification when the command finishes")
+    .option("-c, --criteria <text>", "Alert only when command output contains text")
+    .action((cron: string, cmd: string[], options: { notify?: boolean; criteria?: string }) => {
       const command = cmd.join(" ");
-      const task = { id: randomUUID(), cron, command };
+      const task = {
+        id: randomUUID(),
+        cron,
+        command,
+        notify: options.notify,
+        criteria: options.criteria,
+      };
       addSchedule(task);
       reloadSchedulers();
       console.log(chalk.green(`✓ Scheduled task ${task.id}`));
@@ -32,7 +42,16 @@ export function createScheduleCommand(): Command {
         return;
       }
       console.log(chalk.bold("Scheduled tasks:"));
-      tasks.forEach((t) => console.log(`${t.id}: ${t.cron} -> ${t.command}`));
+      tasks.forEach((t) => {
+        const flags = [
+          t.notify ? "notify" : null,
+          t.criteria ? `criteria: ${t.criteria}` : null,
+        ]
+          .filter(Boolean)
+          .join(", ");
+        const extra = flags ? ` [${flags}]` : "";
+        console.log(`${t.id}: ${t.cron} -> ${t.command}${extra}`);
+      });
     });
 
   scheduleCommand

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,9 +22,24 @@ import os from "os";
 // Load environment variables
 dotenv.config();
 startAllTasks();
-startAllAlerts();
 process.on("SIGUSR1", startAllTasks);
-process.on("SIGUSR2", startAllAlerts);
+
+const ALERT_PID_FILE = path.join(os.homedir(), ".h1dr4", "alerts.pid");
+
+function alertDaemonRunning(): boolean {
+  try {
+    const pid = parseInt(fs.readFileSync(ALERT_PID_FILE, "utf8"), 10);
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+if (!alertDaemonRunning()) {
+  startAllAlerts();
+  process.on("SIGUSR2", startAllAlerts);
+}
 
 const UI_PID_FILE = path.join(os.homedir(), ".h1dr4", "ui.pid");
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ import { createMCPCommand } from "./commands/mcp";
 import { createRSSCommand } from "./commands/rss";
 import { createScheduleCommand } from "./commands/schedule";
 import { startAllTasks } from "./schedule/runner";
+import { createAlertCommand } from "./commands/alert";
+import { startAllAlerts } from "./alerts/runner";
 import type { ChatCompletionMessageParam } from "openai/resources/chat";
 import fs from "fs";
 import path from "path";
@@ -20,7 +22,9 @@ import os from "os";
 // Load environment variables
 dotenv.config();
 startAllTasks();
+startAllAlerts();
 process.on("SIGUSR1", startAllTasks);
+process.on("SIGUSR2", startAllAlerts);
 
 const UI_PID_FILE = path.join(os.homedir(), ".h1dr4", "ui.pid");
 
@@ -472,5 +476,6 @@ gitCommand
 program.addCommand(createMCPCommand());
 program.addCommand(createRSSCommand());
 program.addCommand(createScheduleCommand());
+program.addCommand(createAlertCommand());
 
 program.parse();

--- a/src/schedule/config.ts
+++ b/src/schedule/config.ts
@@ -6,6 +6,8 @@ export interface ScheduledTask {
   id: string;
   cron: string;
   command: string;
+  criteria?: string;
+  notify?: boolean;
 }
 
 const CONFIG_FILE = path.join(os.homedir(), ".h1dr4", "schedules.json");

--- a/src/schedule/runner.ts
+++ b/src/schedule/runner.ts
@@ -1,8 +1,9 @@
 import schedule from "node-schedule";
-import { spawn } from "child_process";
+import { spawn, exec } from "child_process";
 import fs from "fs";
 import path from "path";
 import os from "os";
+import chalk from "chalk";
 import { loadSchedules, ScheduledTask } from "./config";
 import { ConfirmationService } from "../utils/confirmation-service";
 
@@ -30,26 +31,61 @@ export function startAllTasks(): void {
   }
 }
 
-function spawnInTerminal(command: string): void {
+function spawnInTerminal(message: string): void {
   const platform = process.platform;
+
+  const hereDoc = (content: string): string => {
+    const token = `EOF_${Math.random().toString(16).slice(2)}`;
+    return `cat <<'${token}'\n${content}\n${token}\nread`;
+  };
+
+  const script = hereDoc(message);
+
   if (platform === "win32") {
-    spawn("cmd", ["/c", "start", "cmd", "/k", command], { detached: true });
+    const escaped = script.replace(/"/g, '""');
+    const cmd = `start cmd /k "${escaped}"`;
+    spawn("cmd", ["/c", cmd], { detached: true, stdio: "ignore" }).unref();
   } else if (platform === "darwin") {
-    const osa = `tell application \"Terminal\" to do script \"${command.replace(/"/g, '\\"')}\"`;
-    spawn("osascript", ["-e", osa], { detached: true });
+    const escaped = script.replace(/(["\\])/g, "\\$1");
+    const osa = `tell application "Terminal" to do script \"${escaped}\"`;
+    spawn("osascript", ["-e", osa], { detached: true, stdio: "ignore" }).unref();
   } else {
     const term = process.env.TERM_PROGRAM || "x-terminal-emulator";
-    spawn(term, ["-e", command], { detached: true });
+    spawn(term, ["-e", "bash", "-lc", script], {
+      detached: true,
+      stdio: "ignore",
+    }).unref();
+  }
+}
+
+function notify(task: ScheduledTask, output: string, matched: boolean): void {
+  const message = matched && task.criteria
+    ? `TASK ${task.id} matched (criteria: ${task.criteria})`
+    : `TASK ${task.id} completed`;
+  const fullMessage = `${message}\n${output}`;
+  spawnInTerminal(fullMessage);
+  if (process.stdout.isTTY) {
+    console.log(chalk.green(`\n${fullMessage}\n`));
   }
 }
 
 function runTask(task: ScheduledTask): void {
   const confirmationService = ConfirmationService.getInstance();
   confirmationService.setSessionFlag("allOperations", true);
-  if (process.stdout.isTTY) {
-    spawn(task.command, { shell: true, stdio: "inherit" });
-  } else {
-    // no TTY, open in new terminal
-    spawnInTerminal(task.command);
+  if (!task.notify && !task.criteria) {
+    if (process.stdout.isTTY) {
+      spawn(task.command, { shell: true, stdio: "inherit" });
+    } else {
+      spawnInTerminal(task.command);
+    }
+    return;
   }
+
+  exec(task.command, { encoding: "utf8" }, (_err, stdout, stderr) => {
+    const output = `${stdout}${stderr}`;
+    const matched = task.criteria ? output.includes(task.criteria) : false;
+    if (task.notify || matched) {
+      notify(task, output, matched);
+    }
+  });
 }

--- a/src/ui/components/alert-status.tsx
+++ b/src/ui/components/alert-status.tsx
@@ -1,0 +1,33 @@
+import React, { useState, useEffect } from "react";
+import { Box, Text } from "ink";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+const EVENTS_FILE = path.join(os.homedir(), ".h1dr4", "alert-events.json");
+
+export function AlertStatus() {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    const update = () => {
+      try {
+        const events = JSON.parse(fs.readFileSync(EVENTS_FILE, "utf8"));
+        setCount(events.length);
+      } catch {
+        setCount(0);
+      }
+    };
+    update();
+    const interval = setInterval(update, 2000);
+    return () => clearInterval(interval);
+  }, []);
+
+  if (count === 0) return null;
+
+  return (
+    <Box marginLeft={1}>
+      <Text color="red">⚠ alerts: {count} </Text>
+    </Box>
+  );
+}

--- a/src/ui/components/chat-interface.tsx
+++ b/src/ui/components/chat-interface.tsx
@@ -8,6 +8,7 @@ import { ModelSelection } from "./model-selection";
 import { ChatHistory } from "./chat-history";
 import { ChatInput } from "./chat-input";
 import { MCPStatus } from "./mcp-status";
+import { AlertStatus } from "./alert-status";
 import ConfirmationDialog from "./confirmation-dialog";
 import {
   ConfirmationService,
@@ -238,6 +239,7 @@ function ChatInterfaceWithAgent({ agent }: { agent: H1dr4Agent }) {
               <Text color="yellow">≋ {agent.getCurrentModel()}</Text>
             </Box>
             <MCPStatus />
+            <AlertStatus />
           </Box>
 
           <CommandSuggestions


### PR DESCRIPTION
## Summary
- add `alert` CLI command to watch command output for keywords and log alert events
- start background alert runner and daemon with cron-based checks
- surface fired alerts in UI via new `AlertStatus` indicator
- document alert setup with CLI examples and README guidance
- expand agent system instructions with alert setup details

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm run typecheck`
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bc5a10f14c832c8073c5c3ad860ec8