### PR TITLE
feat: add GDELT intelligence tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A conversational AI CLI tool powered by H1DR4 with intelligent text editor capab
 - **🔧 Automatic Tool Selection**: AI intelligently chooses the right tools for your requests
 - **🧠 Reasoning Engine**: Access a dedicated reasoning endpoint for complex questions
 - **🔍 OSINT Search**: Query public data sources using the `osint_search` tool (set `OSINT_TOKEN`)
+- **🌐 GDELT Intelligence**: Correlate 852M+ geopolitical events via the `gdelt_query` tool across historical (v1) and real-time (v2) datasets
 - **🚀 Morph Fast Apply**: Optional high-speed code editing at 4,500+ tokens/sec with 98% accuracy
 - **🔌 MCP Tools**: Extend capabilities with Model Context Protocol servers (Linear, GitHub, etc.)
 - **💬 Interactive UI**: Beautiful terminal interface built with Ink
@@ -95,6 +96,13 @@ or throught
 ```bash
 export OSINT_TOKEN=your-h1dr4_osint-token
 ```
+
+**Optional: Override the GDELT base URL**
+```bash
+export GDELT_BASE_URL=https://your-proxy-or-direct-endpoint
+```
+
+The `gdelt_query` tool defaults to `https://my-search-proxy.ew.r.appspot.com` and exposes both `/gdelt` (v1, 1979-2025 daily refresh) and `/gdelt/v2` (2015-2025, 15-minute refresh) datasets. Prefer v2 for real-time analysis and when working inside the June 14 - July 1 2025 outage window, otherwise use v1 for longer historical sweeps. Each endpoint returns JSON including automatic data quality warnings.
 
 ### Get your Morph API key from [Morph Dashboard](https://morphllm.com/dashboard/api-keys)
 *Note*: For the best coding experience Morph is recomended

--- a/src/agent/h1dr4-agent.ts
+++ b/src/agent/h1dr4-agent.ts
@@ -15,6 +15,7 @@ import {
   ConfirmationTool,
   SearchTool,
   OSINTTool,
+  GdeltTool,
   ReasoningWorker,
 } from "../tools";
 import { ToolResult } from "../types";
@@ -51,6 +52,7 @@ export class H1dr4Agent extends EventEmitter {
   private confirmationTool: ConfirmationTool;
   private search: SearchTool;
   private osint: OSINTTool;
+  private gdelt: GdeltTool;
   private reasoningWorker: ReasoningWorker;
   private chatHistory: ChatEntry[] = [];
   private messages: H1dr4Message[] = [];
@@ -88,6 +90,7 @@ export class H1dr4Agent extends EventEmitter {
     this.confirmationTool = new ConfirmationTool();
     this.search = new SearchTool();
     this.osint = new OSINTTool();
+    this.gdelt = new GdeltTool();
     this.reasoningWorker = new ReasoningWorker();
     this.tokenCounter = createTokenCounter(modelToUse);
 
@@ -118,6 +121,7 @@ You have access to these tools:
 - create_todo_list: Create a visual todo list for planning and tracking tasks
 - update_todo_list: Update existing todos in your todo list
 - osint_search: Perform OSINT leak retrieval for defined entities like email addresses, phone numbers, usernames, or domains
+- gdelt_query: Query the GDELT geopolitical datasets for conflict, risk, economic, or custom event analysis using modular endpoints
 - live_search: Search real-time web, news, and X posts using Grok's live search
 - reason: Use a dedicated reasoning model for predictions, market or geopolitical analysis, strategic planning, and other complex questions
 
@@ -132,6 +136,16 @@ REAL-TIME INFORMATION:
  Provide descriptive queries; mode defaults to auto and all sources are searched unless you specify otherwise.
  Prefer live_search for current events, social media mentions, or up-to-the-minute data instead of the reasoning tool.
  This capability is independent from the reasoning worker and does not require user confirmation.
+
+GDELT DATA PLAYBOOK:
+ - Use the gdelt_query tool for structured geopolitical datasets.
+ - Dataset selection: /gdelt (v1) covers 1979-2025 with daily refresh; /gdelt/v2 covers 2015-2025 with 15-minute refresh and better June 2025 coverage.
+ - Prefer v1 for long-term historical trends and v2 for real-time monitoring or when analyzing the June 14 - July 1 2025 outage window.
+ - Endpoints: connection_test, global_conflict_analysis, country_risk, bilateral_relations, high_impact_events, economic_events, custom_date_search, or provide a custom path.
+ - Global conflict metrics include monthly counts, average sentiment (-100 to +100), and Goldstein impact (-10 to +10).
+ - Country risk accepts ISO3 codes (USA, CHN, RUS, etc.); global/bilateral analyses accept optional month windows; custom date search uses YYYYMMDD ranges.
+ - Set threshold ≥8 for high impact events, tune limits for pagination, and keep date windows focused to optimize BigQuery costs.
+ - The API returns JSON with automatic warnings for the June 2025 gap—follow recommendations and consider cross-checking both datasets for critical work.
 
  IMPORTANT TOOL USAGE RULES:
 - NEVER use create_file on files that already exist - this will overwrite them completely
@@ -738,6 +752,15 @@ Current working directory: ${process.cwd()}`,
 
         case "osint_search":
           return await this.osint.search(args.query);
+
+        case "gdelt_query":
+          return await this.gdelt.query({
+            endpoint: args.endpoint,
+            datasetVersion: args.dataset_version,
+            pathOverride: args.path_override,
+            method: args.method,
+            parameters: args.parameters,
+          });
 
         case "live_search":
           const searchResponse = await this.h1dr4Client.search(

--- a/src/h1dr4/tools.ts
+++ b/src/h1dr4/tools.ts
@@ -261,6 +261,55 @@ const BASE_H1DR4_TOOLS: H1dr4Tool[] = [
   {
     type: "function",
     function: {
+      name: "gdelt_query",
+      description:
+        "Query the GDELT geopolitical datasets for conflict, risk, economic, or custom event intelligence",
+      parameters: {
+        type: "object",
+        properties: {
+          endpoint: {
+            type: "string",
+            enum: [
+              "connection_test",
+              "global_conflict_analysis",
+              "country_risk",
+              "bilateral_relations",
+              "high_impact_events",
+              "economic_events",
+              "custom_date_search",
+              "custom",
+            ],
+            description: "Which GDELT analytical endpoint to call",
+          },
+          dataset_version: {
+            type: "string",
+            enum: ["v1", "v2"],
+            description:
+              "Dataset selection: v1 (1979-2025 daily) or v2 (2015-2025, 15-minute refresh)",
+          },
+          path_override: {
+            type: "string",
+            description:
+              "Optional dataset-relative path override when endpoint is set to custom",
+          },
+          method: {
+            type: "string",
+            enum: ["GET", "POST"],
+            description: "HTTP method (defaults to GET)",
+          },
+          parameters: {
+            type: "object",
+            description:
+              "Query string parameters (for GET) or JSON body (for POST), such as months, start_year, country, limit, threshold, date_start, date_end",
+          },
+        },
+        required: ["endpoint"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
       name: "live_search",
       description:
         "Search real-time web, news, and X posts using Grok's live search",

--- a/src/tools/gdelt.ts
+++ b/src/tools/gdelt.ts
@@ -1,0 +1,129 @@
+import axios, { AxiosError } from "axios";
+import { ToolResult } from "../types";
+
+type DatasetVersion = "v1" | "v2";
+
+type GdeltEndpoint =
+  | "connection_test"
+  | "global_conflict_analysis"
+  | "country_risk"
+  | "bilateral_relations"
+  | "high_impact_events"
+  | "economic_events"
+  | "custom_date_search"
+  | "custom";
+
+export interface GdeltQueryOptions {
+  endpoint: GdeltEndpoint;
+  datasetVersion?: DatasetVersion;
+  /**
+   * Optional override for the dataset-relative path. Required when endpoint is "custom".
+   * Example: "/custom-path" or "" for the dataset root.
+   */
+  pathOverride?: string;
+  /**
+   * Optional HTTP method. Defaults to GET.
+   */
+  method?: "GET" | "POST";
+  /**
+   * Query string parameters for GET requests or request body for POST requests.
+   */
+  parameters?: Record<string, any>;
+}
+
+const DEFAULT_BASE_URL = "https://my-search-proxy.ew.r.appspot.com";
+
+const ENDPOINT_PATHS: Record<Exclude<GdeltEndpoint, "custom">, string> = {
+  connection_test: "",
+  global_conflict_analysis: "/conflict",
+  country_risk: "/country-risk",
+  bilateral_relations: "/bilateral-relations",
+  high_impact_events: "/high-impact-events",
+  economic_events: "/economic-events",
+  custom_date_search: "/custom-date-search",
+};
+
+const DEFAULT_PARAMETERS: Partial<
+  Record<Exclude<GdeltEndpoint, "custom">, Record<string, any>>
+> = {
+  global_conflict_analysis: {
+    months: 6,
+  },
+  country_risk: {
+    limit: 20,
+  },
+  bilateral_relations: {
+    months: 6,
+  },
+  high_impact_events: {
+    threshold: 8.0,
+    limit: 50,
+  },
+  custom_date_search: {
+    limit: 100,
+  },
+};
+
+export class GdeltTool {
+  private readonly baseURL: string;
+
+  constructor(baseURL?: string) {
+    this.baseURL = baseURL || process.env.GDELT_BASE_URL || DEFAULT_BASE_URL;
+  }
+
+  async query(options: GdeltQueryOptions): Promise<ToolResult> {
+    try {
+      const datasetVersion: DatasetVersion = options.datasetVersion || "v1";
+      const datasetPath = datasetVersion === "v2" ? "/gdelt/v2" : "/gdelt";
+      const endpointPath =
+        options.endpoint === "custom"
+          ? options.pathOverride ?? null
+          : ENDPOINT_PATHS[options.endpoint];
+
+      if (endpointPath == null) {
+        return {
+          success: false,
+          error:
+            "Invalid endpoint path. Provide a pathOverride when using the custom endpoint.",
+        };
+      }
+
+      const url = `${this.baseURL}${datasetPath}${endpointPath}`;
+      const method = options.method || "GET";
+      const defaultParams =
+        options.endpoint === "custom"
+          ? {}
+          : DEFAULT_PARAMETERS[options.endpoint] || {};
+      const parameters = { ...defaultParams, ...(options.parameters || {}) };
+
+      const response = await axios.request({
+        method,
+        url,
+        params: method === "GET" ? parameters : undefined,
+        data: method !== "GET" ? parameters : undefined,
+        timeout: 20000,
+      });
+
+      return {
+        success: true,
+        output: JSON.stringify(response.data, null, 2),
+        data: response.data,
+      };
+    } catch (error) {
+      const axiosError = error as AxiosError;
+      const status = axiosError.response?.status;
+      const message =
+        axiosError.response?.data && typeof axiosError.response.data === "object"
+          ? JSON.stringify(axiosError.response.data, null, 2)
+          : axiosError.message;
+
+      return {
+        success: false,
+        error:
+          status != null
+            ? `GDELT request failed with status ${status}: ${message}`
+            : `Failed to reach GDELT API: ${message}`,
+      };
+    }
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,3 +6,4 @@ export { ConfirmationTool } from "./confirmation-tool";
 export { SearchTool } from "./search";
 export { OSINTTool } from "./osint";
 export { ReasoningWorker } from "./reasoning-worker";
+export { GdeltTool } from "./gdelt";


### PR DESCRIPTION
## Summary
- add a reusable `gdelt_query` tool for accessing the GDELT v1 and v2 datasets
- document GDELT usage guidance in the agent instructions and README, including dataset best practices
- expose the new tool through the CLI tool registry so it can be selected during conversations

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d725b67ba0832c952096e38b993152