### PR TITLE
Add GDELT query tool for H1DR4 agent

### DIFF
--- a/src/agent/h1dr4-agent.ts
+++ b/src/agent/h1dr4-agent.ts
@@ -16,6 +16,7 @@ import {
   SearchTool,
   OSINTTool,
   ReasoningWorker,
+  GdeltTool,
 } from "../tools";
 import { ToolResult } from "../types";
 import { EventEmitter } from "events";
@@ -51,6 +52,7 @@ export class H1dr4Agent extends EventEmitter {
   private confirmationTool: ConfirmationTool;
   private search: SearchTool;
   private osint: OSINTTool;
+  private gdelt: GdeltTool;
   private reasoningWorker: ReasoningWorker;
   private chatHistory: ChatEntry[] = [];
   private messages: H1dr4Message[] = [];
@@ -88,6 +90,7 @@ export class H1dr4Agent extends EventEmitter {
     this.confirmationTool = new ConfirmationTool();
     this.search = new SearchTool();
     this.osint = new OSINTTool();
+    this.gdelt = new GdeltTool();
     this.reasoningWorker = new ReasoningWorker();
     this.tokenCounter = createTokenCounter(modelToUse);
 
@@ -118,8 +121,20 @@ You have access to these tools:
 - create_todo_list: Create a visual todo list for planning and tracking tasks
 - update_todo_list: Update existing todos in your todo list
 - osint_search: Perform OSINT leak retrieval for defined entities like email addresses, phone numbers, usernames, or domains
+- gdelt_query: Query the GDELT proxy for conflict levels, country risk, bilateral relations, high-impact or economic events, BBVA-style bilateral conflict coverage, custom date searches, and keyword context retrieval (supports /gdelt and /gdelt/v2 with daily granularity options)
 - live_search: Search real-time web, news, and X posts using Grok's live search
 - reason: Use a dedicated reasoning model for predictions, market or geopolitical analysis, strategic planning, and other complex questions
+
+GDELT TOOL QUICK REFERENCE:
+- test → Check connectivity (/gdelt?action=test)
+- conflict → Global conflict intensity; supports start_year, months, and daily granularity triggers
+- country → Country risk (country code required, optional start_year, limit, daily granularity)
+- bilateral → Bilateral relations (country1, country2, months or date_start/date_end with daily granularity)
+- high-impact → Filter by Goldstein threshold, limit, start_year
+- economic → Economic cooperation/conflict data with start_year, limit, and daily options
+- search → Custom date range search (date_start, date_end, limit)
+- bilateral_conflict_coverage → BBVA directional conflict coverage (actor1_code, actor2_code, date_start, date_end, optional cameos, include_total)
+- context → Keyword-filtered context retrieval (date_start, date_end, optional keywords, limit, include_insights)
 
 REASONING WORKER BEST PRACTICES:
  - Best for: Market analysis, geopolitical intelligence, predictive analysis, strategic planning, Monte Carlo simulations, or complex synthesis of multiple news sources
@@ -738,6 +753,15 @@ Current working directory: ${process.cwd()}`,
 
         case "osint_search":
           return await this.osint.search(args.query);
+
+        case "gdelt_query":
+          return await this.gdelt.query({
+            action: args.action,
+            endpointVersion: args.endpoint_version,
+            params:
+              args.query_parameters ?? args.params ?? args.parameters ?? undefined,
+            timeoutMs: args.timeout_ms,
+          });
 
         case "live_search":
           const searchResponse = await this.h1dr4Client.search(

--- a/src/h1dr4/tools.ts
+++ b/src/h1dr4/tools.ts
@@ -162,6 +162,69 @@ const BASE_H1DR4_TOOLS: H1dr4Tool[] = [
   {
     type: "function",
     function: {
+      name: "gdelt_query",
+      description:
+        "Query the GDELT proxy for conflict trends, country risk, bilateral relations, economic or high-impact events, BBVA-style bilateral conflict coverage, or keyword context data (supports /gdelt and /gdelt/v2 with daily granularity triggers)",
+      parameters: {
+        type: "object",
+        properties: {
+          action: {
+            type: "string",
+            enum: [
+              "test",
+              "conflict",
+              "country",
+              "bilateral",
+              "high-impact",
+              "economic",
+              "search",
+              "bilateral_conflict_coverage",
+              "context",
+            ],
+            description:
+              "Which GDELT action to run. Use 'bilateral_conflict_coverage' for BBVA methodology or 'context' for keyword-filtered events.",
+          },
+          endpoint_version: {
+            type: "string",
+            enum: ["v1", "v2"],
+            description:
+              "Optional override for dataset version. Defaults to /gdelt for most actions and /gdelt/v2 for daily or BBVA/context requests.",
+          },
+          query_parameters: {
+            type: "object",
+            description:
+              "Additional query parameters (e.g. {start_year: 2023, months: 6, date_start: '20250801', date_end: '20250831', granularity: 'daily', country: 'USA'}). Arrays will be sent as repeated parameters.",
+            additionalProperties: {
+              anyOf: [
+                { type: "string" },
+                { type: "number" },
+                { type: "boolean" },
+                {
+                  type: "array",
+                  items: {
+                    anyOf: [
+                      { type: "string" },
+                      { type: "number" },
+                      { type: "boolean" },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+          timeout_ms: {
+            type: "number",
+            description:
+              "Optional request timeout override in milliseconds (default 60000).",
+          },
+        },
+        required: ["action"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
       name: "create_todo_list",
       description: "Create a new todo list for planning and tracking tasks",
       parameters: {

--- a/src/tools/gdelt.ts
+++ b/src/tools/gdelt.ts
@@ -1,0 +1,110 @@
+import axios, { AxiosRequestConfig } from "axios";
+import { ToolResult } from "../types";
+
+type PrimitiveValue = string | number | boolean;
+type ParamValue = PrimitiveValue | PrimitiveValue[];
+
+export interface GdeltQueryArgs {
+  action: string;
+  endpointVersion?: "v1" | "v2";
+  params?: Record<string, ParamValue | undefined>;
+  timeoutMs?: number;
+}
+
+export class GdeltTool {
+  private readonly baseUrl = "https://my-search-proxy.ew.r.appspot.com";
+
+  async query(args: GdeltQueryArgs): Promise<ToolResult> {
+    const { action, endpointVersion, params, timeoutMs } = args;
+
+    if (!action) {
+      return { success: false, error: "Missing required action parameter" };
+    }
+
+    try {
+      const path = this.getEndpointPath(action, endpointVersion);
+      const query = this.buildQueryParams(action, params);
+      const url = `${this.baseUrl}${path}`;
+
+      const requestConfig: AxiosRequestConfig = {
+        method: "GET",
+        url,
+        params: query,
+        paramsSerializer: {
+          serialize: (queryParams) => this.serializeQuery(queryParams as Record<string, ParamValue>),
+        },
+        timeout: timeoutMs ?? 60000,
+      };
+
+      const response = await axios.request(requestConfig);
+      return {
+        success: true,
+        output: JSON.stringify(response.data, null, 2),
+        data: response.data,
+      };
+    } catch (error: any) {
+      const message = error?.response?.data
+        ? JSON.stringify(error.response.data, null, 2)
+        : error?.message || "Unknown error";
+      return {
+        success: false,
+        error: `GDELT request failed: ${message}`,
+      };
+    }
+  }
+
+  private getEndpointPath(action: string, endpointVersion?: "v1" | "v2"): string {
+    if (endpointVersion === "v2") {
+      return "/gdelt/v2";
+    }
+
+    // Certain actions are only available in v2
+    if (["bilateral_conflict_coverage", "context"].includes(action)) {
+      return "/gdelt/v2";
+    }
+
+    return "/gdelt";
+  }
+
+  private buildQueryParams(
+    action: string,
+    params?: Record<string, ParamValue | undefined>
+  ): Record<string, ParamValue> {
+    const query: Record<string, ParamValue> = { action };
+    if (!params) {
+      return query;
+    }
+
+    for (const [key, value] of Object.entries(params)) {
+      if (value === undefined || value === null) {
+        continue;
+      }
+      query[key] = value;
+    }
+
+    return query;
+  }
+
+  private serializeQuery(params: Record<string, ParamValue>): string {
+    const searchParams = new URLSearchParams();
+
+    for (const [key, value] of Object.entries(params)) {
+      if (Array.isArray(value)) {
+        value.forEach((item) => {
+          searchParams.append(key, this.stringifyValue(item));
+        });
+      } else {
+        searchParams.append(key, this.stringifyValue(value));
+      }
+    }
+
+    return searchParams.toString();
+  }
+
+  private stringifyValue(value: PrimitiveValue): string {
+    if (typeof value === "boolean") {
+      return value ? "true" : "false";
+    }
+    return String(value);
+  }
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,3 +6,4 @@ export { ConfirmationTool } from "./confirmation-tool";
 export { SearchTool } from "./search";
 export { OSINTTool } from "./osint";
 export { ReasoningWorker } from "./reasoning-worker";
+export { GdeltTool } from "./gdelt";


### PR DESCRIPTION
## Summary
- add a dedicated GDELT tool with dynamic parameter serialization and automatic endpoint selection
- register the gdelt_query tool in the CLI exports and tool schema so it is available to the agent
- extend the agent instructions and dispatcher to cover GDELT usage and expose all supported actions

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dc50283810832ca7ca87e43beaad4c