### PR TITLE
Add Shannon pentest integration tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A conversational AI CLI tool powered by H1DR4 with intelligent text editor capab
 - **🧠 Reasoning Engine**: Access a dedicated reasoning endpoint for complex questions
 - **🔍 OSINT Search**: Query public data sources using the `osint_search` tool (set `OSINT_TOKEN`)
 - **🚀 Morph Fast Apply**: Optional high-speed code editing at 4,500+ tokens/sec with 98% accuracy
+- **🔐 Shannon Integration**: Launch Shannon autonomous pentests directly from the CLI via Docker
 - **🔌 MCP Tools**: Extend capabilities with Model Context Protocol servers (Linear, GitHub, etc.)
 - **💬 Interactive UI**: Beautiful terminal interface built with Ink
 - While the agent is executing tasks, you can continue typing new requests.
@@ -362,6 +363,25 @@ h1dr4 -p "convert this class to TypeScript and add proper type annotations"
 ```
 
 The AI will automatically choose between `edit_file` (Morph) for complex changes or `str_replace_editor` for simple replacements.
+
+## Shannon Integration
+
+Use the `run_shannon` tool to launch [Shannon](https://github.com/KeygraphHQ/shannon) autonomous pentests without leaving the H1DR4 CLI.
+
+**Prerequisites**
+
+- Docker available on your machine
+- A Shannon image (defaults to `shannon:latest`; override with the `image` parameter)
+- `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` set in your environment (optionally `CLAUDE_CODE_MAX_OUTPUT_TOKENS`)
+- Optional Shannon config file for authenticated runs
+
+**Usage**
+
+The tool mounts `repo_path` (defaults to the current working directory) to `/app/repos/target`, mounts the config file directory to `/app/configs`, and uses `--network host` unless you set `disable_host_network`.
+
+```bash
+h1dr4 --prompt "run run_shannon on http://host.docker.internal:3000 with config ./configs/example-config.yaml"
+```
 
 ## MCP Tools
 

--- a/src/agent/h1dr4-agent.ts
+++ b/src/agent/h1dr4-agent.ts
@@ -16,6 +16,7 @@ import {
   SearchTool,
   OSINTTool,
   ReasoningWorker,
+  ShannonTool,
 } from "../tools";
 import { ToolResult } from "../types";
 import { EventEmitter } from "events";
@@ -52,6 +53,7 @@ export class H1dr4Agent extends EventEmitter {
   private search: SearchTool;
   private osint: OSINTTool;
   private reasoningWorker: ReasoningWorker;
+  private shannon: ShannonTool;
   private chatHistory: ChatEntry[] = [];
   private messages: H1dr4Message[] = [];
   private tokenCounter: TokenCounter;
@@ -89,6 +91,7 @@ export class H1dr4Agent extends EventEmitter {
     this.search = new SearchTool();
     this.osint = new OSINTTool();
     this.reasoningWorker = new ReasoningWorker();
+    this.shannon = new ShannonTool();
     this.tokenCounter = createTokenCounter(modelToUse);
 
     // Initialize MCP servers if configured
@@ -120,6 +123,7 @@ You have access to these tools:
 - osint_search: Perform OSINT leak retrieval for defined entities like email addresses, phone numbers, usernames, or domains
 - live_search: Search real-time web, news, and X posts using Grok's live search
 - reason: Use a dedicated reasoning model for predictions, market or geopolitical analysis, strategic planning, and other complex questions
+- run_shannon: Launch the Shannon autonomous pentest via Docker (requires local Docker and Anthropic credentials)
 
 REASONING WORKER BEST PRACTICES:
  - Best for: Market analysis, geopolitical intelligence, predictive analysis, strategic planning, Monte Carlo simulations, or complex synthesis of multiple news sources
@@ -728,6 +732,16 @@ Current working directory: ${process.cwd()}`,
               searchResponse.choices[0]?.message?.content ||
               "No results returned",
           };
+
+        case "run_shannon":
+          return await this.shannon.runScan({
+            targetUrl: args.target_url,
+            repoPath: args.repo_path,
+            configPath: args.config_path,
+            image: args.image,
+            disableHostNetwork: args.disable_host_network,
+            additionalArgs: args.additional_args,
+          });
 
         case "reason":
           const confirmation = await this.confirmationTool.requestConfirmation({

--- a/src/h1dr4/tools.ts
+++ b/src/h1dr4/tools.ts
@@ -294,6 +294,45 @@ const BASE_H1DR4_TOOLS: H1dr4Tool[] = [
   {
     type: "function",
     function: {
+      name: "run_shannon",
+      description:
+        "Run the Shannon autonomous pentester via Docker. Requires Anthropic credentials and local Docker access.",
+      parameters: {
+        type: "object",
+        properties: {
+          target_url: {
+            type: "string",
+            description: "Target URL of the application to test",
+          },
+          repo_path: {
+            type: "string",
+            description: "Local path to mount as /app/repos/target (defaults to current working directory)",
+          },
+          config_path: {
+            type: "string",
+            description: "Optional path to a Shannon config file to mount at /app/configs",
+          },
+          image: {
+            type: "string",
+            description: "Docker image to use for Shannon (default: shannon:latest)",
+          },
+          disable_host_network: {
+            type: "boolean",
+            description: "Set true to avoid using --network host",
+          },
+          additional_args: {
+            type: "array",
+            items: { type: "string" },
+            description: "Additional CLI arguments to pass to Shannon",
+          },
+        },
+        required: ["target_url"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
       name: "reason",
       description:
         "Use a dedicated reasoning model for predictions, cross-referencing news, running simulations (e.g., Monte Carlo), and other complex questions",

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,3 +6,4 @@ export { ConfirmationTool } from "./confirmation-tool";
 export { SearchTool } from "./search";
 export { OSINTTool } from "./osint";
 export { ReasoningWorker } from "./reasoning-worker";
+export { ShannonTool } from "./shannon";

--- a/src/tools/shannon.ts
+++ b/src/tools/shannon.ts
@@ -1,0 +1,160 @@
+import { spawn } from "child_process";
+import * as path from "path";
+import * as fs from "fs-extra";
+import { ToolResult } from "../types";
+import { ConfirmationService } from "../utils/confirmation-service";
+
+interface ShannonRunOptions {
+  targetUrl: string;
+  repoPath?: string;
+  configPath?: string;
+  image?: string;
+  disableHostNetwork?: boolean;
+  additionalArgs?: string[];
+}
+
+export class ShannonTool {
+  private confirmationService = ConfirmationService.getInstance();
+
+  async runScan(options: ShannonRunOptions): Promise<ToolResult> {
+    const { targetUrl, repoPath, configPath, image, disableHostNetwork, additionalArgs } = options;
+
+    if (!targetUrl) {
+      return { success: false, error: "target_url is required" };
+    }
+
+    const resolvedRepoPath = path.resolve(repoPath || process.cwd());
+    if (!(await fs.pathExists(resolvedRepoPath))) {
+      return {
+        success: false,
+        error: `Repository path does not exist: ${resolvedRepoPath}`,
+      };
+    }
+
+    if (configPath && !(await fs.pathExists(configPath))) {
+      return {
+        success: false,
+        error: `Config file not found at: ${path.resolve(configPath)}`,
+      };
+    }
+
+    const { envArgs, missingCredentialMessage } = this.buildCredentialEnv();
+    if (missingCredentialMessage) {
+      return { success: false, error: missingCredentialMessage };
+    }
+
+    const dockerArgs = ["run", "--rm", "--cap-add=NET_RAW", "--cap-add=NET_ADMIN"];
+    if (!disableHostNetwork) {
+      dockerArgs.push("--network", "host");
+    }
+
+    dockerArgs.push("-v", `${resolvedRepoPath}:/app/repos/target`);
+
+    if (configPath) {
+      const resolvedConfig = path.resolve(configPath);
+      dockerArgs.push("-v", `${path.dirname(resolvedConfig)}:/app/configs`);
+    }
+
+    if (process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS) {
+      dockerArgs.push(
+        "-e",
+        `CLAUDE_CODE_MAX_OUTPUT_TOKENS=${process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS}`
+      );
+    }
+
+    envArgs.forEach((envVar) => {
+      dockerArgs.push("-e", envVar);
+    });
+
+    const imageName = image || "shannon:latest";
+    dockerArgs.push(imageName, targetUrl, "/app/repos/target");
+
+    if (configPath) {
+      const containerConfigPath = `/app/configs/${path.basename(configPath)}`;
+      dockerArgs.push("--config", containerConfigPath);
+    }
+
+    if (additionalArgs?.length) {
+      dockerArgs.push(...additionalArgs);
+    }
+
+    const commandPreview = ["docker", ...dockerArgs].join(" ");
+
+    const confirmationResult = await this.confirmationService.requestConfirmation(
+      {
+        operation: "Run Shannon pentest",
+        filename: imageName,
+        content: `Command: ${commandPreview}`,
+        showVSCodeOpen: false,
+      },
+      "bash"
+    );
+
+    if (!confirmationResult.confirmed) {
+      return {
+        success: false,
+        error: confirmationResult.feedback || "Shannon execution cancelled by user",
+      };
+    }
+
+    return await this.executeDockerCommand(dockerArgs, commandPreview);
+  }
+
+  private async executeDockerCommand(args: string[], preview: string): Promise<ToolResult> {
+    return new Promise((resolve) => {
+      const dockerProcess = spawn("docker", args, { env: process.env });
+      let output = "";
+      let errorOutput = "";
+
+      dockerProcess.stdout.on("data", (data) => {
+        output += data.toString();
+      });
+
+      dockerProcess.stderr.on("data", (data) => {
+        errorOutput += data.toString();
+      });
+
+      dockerProcess.on("error", (error) => {
+        resolve({
+          success: false,
+          error: `Failed to start Docker: ${error.message}`,
+        });
+      });
+
+      dockerProcess.on("close", (code) => {
+        if (code === 0) {
+          resolve({ success: true, output: output.trim() || preview });
+        } else {
+          resolve({
+            success: false,
+            error:
+              errorOutput.trim() ||
+              `Shannon run failed with exit code ${code ?? "unknown"}`,
+          });
+        }
+      });
+    });
+  }
+
+  private buildCredentialEnv(): { envArgs: string[]; missingCredentialMessage?: string } {
+    const envArgs: string[] = [];
+
+    if (process.env.CLAUDE_CODE_OAUTH_TOKEN) {
+      envArgs.push(`CLAUDE_CODE_OAUTH_TOKEN=${process.env.CLAUDE_CODE_OAUTH_TOKEN}`);
+    }
+
+    if (process.env.ANTHROPIC_API_KEY) {
+      envArgs.push(`ANTHROPIC_API_KEY=${process.env.ANTHROPIC_API_KEY}`);
+    }
+
+    if (envArgs.length === 0) {
+      return {
+        envArgs,
+        missingCredentialMessage:
+          "Set CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY to run Shannon inside the CLI.",
+      };
+    }
+
+    return { envArgs };
+  }
+}


### PR DESCRIPTION
## Summary
- add a Shannon wrapper tool that launches dockerized runs with credential checks and confirmation
- wire the new run_shannon tool into the agent tool set so the model can invoke it
- document Shannon integration, prerequisites, and example usage in the README

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69405c754024832c9145f9788bf8a25e)