### PR TITLE
perf: disable model-based tool router by default to reduce latency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,16 @@ A conversational AI CLI tool powered by H1DR4 with intelligent text editor capab
 
 ## Features
 
-- **🤖 Conversational AI**: Natural language interface powered by H1DR4
+- **🤖 Conversational AI**: Natural language interface powered by H1DR4 or local Ollama models
 - **📝 Smart File Operations**: AI automatically uses tools to view, create, and edit files
 - **⚡ Bash Integration**: Execute shell commands through natural conversation
 - **🔧 Automatic Tool Selection**: AI intelligently chooses the right tools for your requests
+- **🌐 Local Live Search**: DuckDuckGo traversal + page scraping with citations (no paid APIs)
 - **🧠 Reasoning Engine**: Access a dedicated reasoning endpoint for complex questions
 - **🔍 OSINT Search**: Query public data sources using the `osint_search` tool (set `OSINT_TOKEN`)
 - **🚀 Morph Fast Apply**: Optional high-speed code editing at 4,500+ tokens/sec with 98% accuracy
 - **🔌 MCP Tools**: Extend capabilities with Model Context Protocol servers (Linear, GitHub, etc.)
+- **🛡️ Shannon Integration**: Run autonomous pentesting workflows via the Shannon CLI
 - **💬 Interactive UI**: Beautiful terminal interface built with Ink
 - While the agent is executing tasks, you can continue typing new requests.
 These messages are queued and the active plan is updated on the fly—no need
@@ -24,7 +26,8 @@ to cancel the current run.
 
 ### Prerequisites
 - Node.js 16+
-- Grok API key from X.AI
+- **For local mode:** Ollama installed (https://ollama.com)
+- **For Grok mode:** Grok API key from X.AI
 - (Optional, Recommended) Morph API key for Fast Apply editing
 
 ### Global Installation (Recommended)
@@ -45,11 +48,9 @@ npm link
 
 ## Setup
 
-## Setup
+### 1. Get your credentials (Grok mode)
 
-### 1. Get your credentials
-
-You will need **a Grok API Key** (required) and optionally an **OSINT Access Token** (recommended for best experience).  
+You will need **a Grok API Key** (required for Grok mode) and optionally an **OSINT Access Token** (recommended for best experience).  
 
 There are **two ways** to get a Grok API Key:
 
@@ -128,6 +129,51 @@ Add to `~/.h1dr4/user-settings.json`:
 }
 ```
 
+### 2. Local Ollama mode (no paid API keys)
+
+Install Ollama and pull one of the supported models:
+
+```bash
+ollama pull huihui_ai/qwen2.5-coder-abliterate:7b
+```
+
+Run the CLI in local mode:
+
+```bash
+export H1DR4_PROVIDER=ollama
+export OLLAMA_BASE_URL=http://localhost:11434
+export H1DR4_MODEL=huihui_ai/qwen2.5-coder-abliterate:7b
+h1dr4
+```
+
+Supported Ollama models (user-selectable):
+- huihui_ai/deepseek-r1-abliterated:8b-llama-distill
+- mannix/smallthinker-abliterated:latest
+- local-agent:latest
+- huihui_ai/qwen2.5-coder-abliterate:7b (default)
+
+Example prompts:
+- "Search latest news about X and summarize with citations"
+- "Plot token price series from CSV"
+
+### 3. Shannon integration (autonomous pentesting)
+
+Clone and set up Shannon:
+
+```bash
+git clone https://github.com/KeygraphHQ/shannon.git
+cd shannon
+./shannon start URL=https://your-app.com REPO=/path/to/your/repo
+```
+
+Then, from H1DR4 CLI, ask the assistant to run Shannon workflows:
+
+```
+"Run Shannon start URL=https://your-app.com REPO=/path/to/your/repo"
+"Show Shannon logs"
+"Query Shannon workflow ID=shannon-1234567890"
+```
+
 ## Usage
 
 ### Interactive Mode
@@ -160,7 +206,7 @@ This mode is particularly useful for:
 
 ### Tool Execution Control
 
-By default, H1DR4 CLI allows up to 400 tool execution rounds to handle complex multi-step tasks. You can control this behavior:
+By default, H1DR4 CLI allows up to 8 tool execution rounds for Ollama and 400 for other providers. You can control this behavior:
 
 ```bash
 # Limit tool rounds for faster execution on simple tasks
@@ -168,6 +214,11 @@ h1dr4 --max-tool-rounds 10 --prompt "show me the current directory"
 
 # Increase limit for very complex tasks (use with caution)
 h1dr4 --max-tool-rounds 1000 --prompt "comprehensive code refactoring"
+
+h1dr4 --max-tool-rounds 20  # Interactive mode
+
+# Or use environment variable
+export MAX_TOOL_ITERS=12
 
 # Works with all modes
 h1dr4 --max-tool-rounds 20  # Interactive mode
@@ -185,10 +236,13 @@ You can specify which AI model to use with the `--model` parameter or `H1DR4_MOD
 
 **Method 1: Command Line Flag**
 ```bash
-# Use H1DR4 models
+# Use H1DR4 models (Grok)
 h1dr4 --model grok-4-latest
 h1dr4 --model grok-3-latest
 h1dr4 --model grok-3-fast
+
+# Use local Ollama models
+h1dr4 --model huihui_ai/qwen2.5-coder-abliterate:7b --base-url http://localhost:11434
 
 # Use other models (with appropriate API endpoint)
 h1dr4 --model gemini-2.5-pro --base-url https://api-endpoint.com/v1

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "axios": "^1.6.0",
         "cfonts": "^3.3.0",
         "chalk": "^4.1.2",
+        "cheerio": "^1.2.0",
         "commander": "^11.1.0",
         "dotenv": "^16.3.0",
         "enquirer": "^2.4.1",
@@ -32,6 +33,7 @@
         "h1dr4": "dist/index.js"
       },
       "devDependencies": {
+        "@types/cheerio": "^0.22.35",
         "@types/fs-extra": "^11.0.2",
         "@types/node": "^20.8.0",
         "@types/node-schedule": "^2.1.3",
@@ -1290,6 +1292,16 @@
       "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
       "license": "MIT"
     },
+    "node_modules/@types/cheerio": {
+      "version": "0.22.35",
+      "resolved": "https://registry.npmjs.org/@types/cheerio/-/cheerio-0.22.35.tgz",
+      "integrity": "sha512-yD57BchKRvTV+JD53UZ6PD8KWY5g5rvvMLRnZR3EQBCZXiDT/HR+pKpMzFGlWNhFrXlo7VPZXtKvIEwZkAWOIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1990,6 +2002,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -2167,6 +2185,48 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/ci-info": {
@@ -2375,6 +2435,34 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -2473,10 +2561,77 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/dom-walk": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
     },
     "node_modules/dotenv": {
       "version": "16.6.1",
@@ -2529,6 +2684,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
       }
     },
     "node_modules/enquirer": {
@@ -3471,6 +3639,37 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -4326,6 +4525,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4506,6 +4717,55 @@
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
       "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
       "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
@@ -6102,6 +6362,15 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/undici": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.19.2.tgz",
+      "integrity": "sha512-4VQSpGEGsWzk0VYxyB/wVX/Q7qf9t5znLRgs0dzszr9w9Fej/8RVNQ+S20vdXSAyra/bJ7ZQfGv6ZMj7UEbzSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -6161,6 +6430,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -27,31 +27,33 @@
     "axios": "^1.6.0",
     "cfonts": "^3.3.0",
     "chalk": "^4.1.2",
+    "cheerio": "^1.2.0",
     "commander": "^11.1.0",
     "dotenv": "^16.3.0",
     "enquirer": "^2.4.1",
     "fs-extra": "^11.1.1",
     "ink": "^3.2.0",
     "ink-markdown": "^1.0.4",
+    "node-schedule": "^2.1.1",
     "openai": "^5.10.1",
     "react": "^17.0.2",
     "ripgrep-node": "^1.0.0",
-    "tiktoken": "^1.0.21",
-    "zod": "^3.25.76",
-    "node-schedule": "^2.1.1",
     "rss-parser": "^3.12.0",
-    "terminal-image": "^2.0.0"
+    "terminal-image": "^2.0.0",
+    "tiktoken": "^1.0.21",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
+    "@types/cheerio": "^0.22.35",
     "@types/fs-extra": "^11.0.2",
     "@types/node": "^20.8.0",
+    "@types/node-schedule": "^2.1.3",
     "@types/react": "^17.0.0",
     "@typescript-eslint/eslint-plugin": "^8.37.0",
     "@typescript-eslint/parser": "^8.37.0",
     "eslint": "^9.31.0",
     "tsx": "^4.0.0",
-    "typescript": "^4.9.5",
-    "@types/node-schedule": "^2.1.3"
+    "typescript": "^4.9.5"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/src/agent/h1dr4-agent.ts
+++ b/src/agent/h1dr4-agent.ts
@@ -1,4 +1,9 @@
-import { H1dr4Client, H1dr4Message, H1dr4ToolCall } from "../h1dr4/client";
+import {
+  H1dr4Client,
+  H1dr4Message,
+  H1dr4Tool,
+  H1dr4ToolCall,
+} from "../h1dr4/client";
 import {
   H1DR4_TOOLS,
   addMCPToolsToH1dr4Tools,
@@ -17,6 +22,8 @@ import {
   OSINTTool,
   ReasoningWorker,
   GdeltTool,
+  LiveSearchTool,
+  ShannonTool,
 } from "../tools";
 import { ToolResult } from "../types";
 import { EventEmitter } from "events";
@@ -53,6 +60,8 @@ export class H1dr4Agent extends EventEmitter {
   private search: SearchTool;
   private osint: OSINTTool;
   private gdelt: GdeltTool;
+  private liveSearch: LiveSearchTool;
+  private shannon: ShannonTool;
   private reasoningWorker: ReasoningWorker;
   private chatHistory: ChatEntry[] = [];
   private messages: H1dr4Message[] = [];
@@ -70,8 +79,17 @@ export class H1dr4Agent extends EventEmitter {
     super();
     const manager = getSettingsManager();
     const savedModel = manager.getCurrentModel();
-    const modelToUse = model || savedModel || "grok-4-latest";
-    this.maxToolRounds = maxToolRounds || 400;
+    const provider =
+      process.env.H1DR4_PROVIDER?.toLowerCase() === "ollama"
+        ? "ollama"
+        : "grok";
+    const modelToUse =
+      provider === "ollama"
+        ? model ||
+          process.env.H1DR4_MODEL ||
+          "closex/neuraldaredevil-8b-abliterated:Q6_K"
+        : model || savedModel || "grok-4-latest";
+    this.maxToolRounds = maxToolRounds || (provider === "ollama" ? 8 : 400);
     this.h1dr4Client = new H1dr4Client(apiKey, modelToUse, baseURL);
     this.textEditor = new TextEditorTool();
     this.morphEditor = process.env.MORPH_API_KEY ? new MorphEditorTool() : null;
@@ -91,6 +109,8 @@ export class H1dr4Agent extends EventEmitter {
     this.search = new SearchTool();
     this.osint = new OSINTTool();
     this.gdelt = new GdeltTool();
+    this.liveSearch = new LiveSearchTool();
+    this.shannon = new ShannonTool();
     this.reasoningWorker = new ReasoningWorker();
     this.tokenCounter = createTokenCounter(modelToUse);
 
@@ -122,7 +142,8 @@ You have access to these tools:
 - update_todo_list: Update existing todos in your todo list
 - osint_search: Perform OSINT leak retrieval for defined entities like email addresses, phone numbers, usernames, or domains
 - gdelt_query: Query the GDELT proxy for conflict levels, country risk, bilateral relations, high-impact or economic events, BBVA-style bilateral conflict coverage, custom date searches, and keyword context retrieval (supports /gdelt and /gdelt/v2 with daily granularity options)
-- live_search: Search real-time web, news, and X posts using Grok's live search
+- live_search: Search the live web with DuckDuckGo and optionally fetch pages with citations
+- shannon: Run Shannon's autonomous pentesting CLI workflows (start, logs, query, stop)
 - reason: Use a dedicated reasoning model for predictions, market or geopolitical analysis, strategic planning, and other complex questions
 
 GDELT TOOL QUICK REFERENCE:
@@ -143,10 +164,10 @@ REASONING WORKER BEST PRACTICES:
 - Ineffective queries are vague, lack context, or are single words
 
 REAL-TIME INFORMATION:
- Use the live_search tool to query real-time web, news, and X (Twitter) data via Grok's live search.
- Provide descriptive queries; mode defaults to auto and all sources are searched unless you specify otherwise.
- Prefer live_search for current events, social media mentions, or up-to-the-minute data instead of the reasoning tool.
- This capability is independent from the reasoning worker and does not require user confirmation.
+ Use the live_search tool to query the web via DuckDuckGo and fetch readable page excerpts.
+ When using live_search, cite sources using the returned citations array.
+ Prefer short excerpts; do not paste entire articles.
+ Prefer live_search for current events instead of the reasoning tool.
 
  IMPORTANT TOOL USAGE RULES:
 - NEVER use create_file on files that already exist - this will overwrite them completely
@@ -207,12 +228,17 @@ If a user rejects an operation, the tool will return an error and you should not
 Be helpful, direct, and efficient. Always explain what you're doing and show the results.
 
 IMPORTANT RESPONSE GUIDELINES:
+- If a user request can be fulfilled by a tool, call the tool immediately.
+- Do NOT explain the tool call; execute it and respond with results.
+- Never fabricate tool outputs. If a tool is required and cannot be called, say so.
 - After using tools, do NOT respond with pleasantries like "Thanks for..." or "Great!"
 - Only provide necessary explanations or next steps if relevant to the task
 - Keep responses concise and focused on the actual work being done
 - If a tool execution completes the user's request, you can remain silent or give a brief confirmation
 
-Current working directory: ${process.cwd()}`,
+Current working directory: ${process.cwd()}
+
+You can call tools for web search and charting.`,
     });
   }
 
@@ -259,6 +285,51 @@ Current working directory: ${process.cwd()}`,
 
     try {
       const tools = await getAllH1dr4Tools();
+      if (this.shouldUseToolRouter()) {
+        const selectedToolCall = await this.selectToolCallUsingModel(
+          message,
+          tools
+        );
+        if (selectedToolCall) {
+          toolRounds++;
+          const assistantEntry: ChatEntry = {
+            type: "assistant",
+            content: "",
+            timestamp: new Date(),
+            toolCalls: [selectedToolCall],
+          };
+          this.chatHistory.push(assistantEntry);
+          newEntries.push(assistantEntry);
+          this.messages.push({
+            role: "assistant",
+            content: "",
+            tool_calls: [selectedToolCall],
+          } as any);
+
+          const toolCallEntry: ChatEntry = {
+            type: "tool_call",
+            content: "Executing...",
+            timestamp: new Date(),
+            toolCall: selectedToolCall,
+          };
+          this.chatHistory.push(toolCallEntry);
+          newEntries.push(toolCallEntry);
+
+          const result = await this.executeTool(selectedToolCall);
+          const updatedEntry: ChatEntry = {
+            ...toolCallEntry,
+            type: "tool_result",
+            content: result.success
+              ? result.output || "Success"
+              : result.error || "Error occurred",
+            toolResult: result,
+          };
+          this.chatHistory.push(updatedEntry);
+          newEntries.push(updatedEntry);
+          this.appendToolResultMessage(selectedToolCall, result);
+        }
+      }
+
       let currentResponse = await this.h1dr4Client.chat(
         this.messages,
         tools,
@@ -272,6 +343,18 @@ Current working directory: ${process.cwd()}`,
 
         if (!assistantMessage) {
           throw new Error("No response from H1dr4");
+        }
+
+        const fallbackToolCalls = this.extractToolCallsFromContent(
+          assistantMessage.content
+        );
+        if (
+          (!assistantMessage.tool_calls ||
+            assistantMessage.tool_calls.length === 0) &&
+          fallbackToolCalls.length > 0
+        ) {
+          assistantMessage.tool_calls = fallbackToolCalls;
+          assistantMessage.content = "";
         }
 
         // Handle tool calls
@@ -343,13 +426,7 @@ Current working directory: ${process.cwd()}`,
             }
 
             // Add tool result to messages with proper format (needed for AI context)
-            this.messages.push({
-              role: "tool",
-              content: result.success
-                ? result.output || "Success"
-                : result.error || "Error",
-              tool_call_id: toolCall.id,
-            });
+            this.appendToolResultMessage(toolCall, result);
           }
 
           // Get next response - this might contain more tool calls
@@ -462,6 +539,51 @@ Current working directory: ${process.cwd()}`,
     let totalOutputTokens = 0;
 
     try {
+      const tools = await getAllH1dr4Tools();
+      if (this.shouldUseToolRouter()) {
+        const selectedToolCall = await this.selectToolCallUsingModel(
+          message,
+          tools
+        );
+        if (selectedToolCall) {
+          toolRounds++;
+          const assistantEntry: ChatEntry = {
+            type: "assistant",
+            content: "",
+            timestamp: new Date(),
+            toolCalls: [selectedToolCall],
+          };
+          this.chatHistory.push(assistantEntry);
+          this.messages.push({
+            role: "assistant",
+            content: "",
+            tool_calls: [selectedToolCall],
+          } as any);
+          yield {
+            type: "tool_calls",
+            toolCalls: [selectedToolCall],
+          };
+
+          const result = await this.executeTool(selectedToolCall);
+          const toolResultEntry: ChatEntry = {
+            type: "tool_result",
+            content: result.success
+              ? result.output || "Success"
+              : result.error || "Error occurred",
+            timestamp: new Date(),
+            toolCall: selectedToolCall,
+            toolResult: result,
+          };
+          this.chatHistory.push(toolResultEntry);
+          yield {
+            type: "tool_result",
+            toolCall: selectedToolCall,
+            toolResult: result,
+          };
+          this.appendToolResultMessage(selectedToolCall, result);
+        }
+      }
+
       // Agent loop - continue until no more tool calls or max rounds reached
       while (toolRounds < maxToolRounds) {
         // Check if operation was cancelled
@@ -475,7 +597,6 @@ Current working directory: ${process.cwd()}`,
         }
 
         // Stream response and accumulate
-        const tools = await getAllH1dr4Tools();
         const stream = this.h1dr4Client.chatStream(
           this.messages,
           tools,
@@ -546,6 +667,18 @@ Current working directory: ${process.cwd()}`,
           }
         }
 
+        const fallbackToolCalls = this.extractToolCallsFromContent(
+          accumulatedMessage.content
+        );
+        if (
+          (!accumulatedMessage.tool_calls ||
+            accumulatedMessage.tool_calls.length === 0) &&
+          fallbackToolCalls.length > 0
+        ) {
+          accumulatedMessage.tool_calls = fallbackToolCalls;
+          accumulatedMessage.content = "";
+        }
+
         // Add assistant entry to history
         const assistantEntry: ChatEntry = {
           type: "assistant",
@@ -606,13 +739,7 @@ Current working directory: ${process.cwd()}`,
             };
 
             // Add tool result with proper format (needed for AI context)
-            this.messages.push({
-              role: "tool",
-              content: result.success
-                ? result.output || "Success"
-                : result.error || "Error",
-              tool_call_id: toolCall.id,
-            });
+            this.appendToolResultMessage(toolCall, result);
           }
 
           // Update token count after processing all tool calls to include tool results
@@ -764,16 +891,22 @@ Current working directory: ${process.cwd()}`,
           });
 
         case "live_search":
-          const searchResponse = await this.h1dr4Client.search(
-            args.query,
-            args.search_parameters
-          );
-          return {
-            success: true,
-            output:
-              searchResponse.choices[0]?.message?.content ||
-              "No results returned",
-          };
+          return await this.liveSearch.search({
+            query: args.query,
+            max_results: args.max_results,
+            fetch_pages: args.fetch_pages,
+            max_chars_per_page: args.max_chars_per_page,
+            region: args.region,
+            safe: args.safe,
+          });
+
+        case "shannon":
+          return await this.shannon.run({
+            command: args.command,
+            working_directory: args.working_directory,
+            env: args.env,
+            timeout_ms: args.timeout_ms,
+          });
 
         case "reason":
           const confirmation = await this.confirmationTool.requestConfirmation({
@@ -881,6 +1014,136 @@ Current working directory: ${process.cwd()}`,
         error: `MCP tool execution error: ${error.message}`,
       };
     }
+  }
+
+  private extractToolCallsFromContent(content?: string | null): H1dr4ToolCall[] {
+    if (!content) {
+      return [];
+    }
+
+    const trimmed = content.trim();
+    const jsonMatch =
+      trimmed.startsWith("{") && trimmed.endsWith("}")
+        ? trimmed
+        : trimmed.match(/```json\s*([\s\S]*?)```/i)?.[1]?.trim() ||
+          trimmed.match(/```([\s\S]*?)```/i)?.[1]?.trim();
+
+    if (!jsonMatch) {
+      return [];
+    }
+
+    try {
+      const parsed = JSON.parse(jsonMatch);
+      if (!parsed || parsed.name === null || parsed.name === undefined) {
+        return [];
+      }
+      const args =
+        typeof parsed.arguments === "string"
+          ? parsed.arguments
+          : JSON.stringify(parsed.arguments ?? {});
+      return [
+        {
+          id: `fallback-${Date.now()}`,
+          type: "function",
+          function: {
+            name: parsed.name,
+            arguments: args,
+          },
+        },
+      ];
+    } catch {
+      return [];
+    }
+  }
+
+  private async selectToolCallUsingModel(
+    message: string,
+    tools: H1dr4Tool[]
+  ): Promise<H1dr4ToolCall | null> {
+    if (tools.length === 0) {
+      return null;
+    }
+
+    const toolSummaries = tools
+      .map((tool) => {
+        const params = tool.function.parameters
+          ? JSON.stringify(tool.function.parameters)
+          : "{}";
+        return `- ${tool.function.name}: ${tool.function.description}\n  params: ${params}`;
+      })
+      .join("\n");
+
+    const selectionPrompt = [
+      {
+        role: "system",
+        content:
+          "You are a tool router. If a tool can answer the request, you MUST call it. " +
+          "Return ONLY JSON: {\"name\": <toolName>, \"arguments\": {..}} " +
+          "or {\"name\": null} if no tool is needed. Do not include code fences.",
+      },
+      {
+        role: "user",
+        content: `User request:\n${message}\n\nAvailable tools:\n${toolSummaries}`,
+      },
+    ];
+
+    const response = await this.h1dr4Client.chat(
+      selectionPrompt as any,
+      tools,
+      undefined,
+      undefined,
+      {
+        temperature: 0,
+        max_tokens: 256,
+        tool_choice: "auto",
+      }
+    );
+    const messageContent = response.choices[0]?.message?.content || "";
+    const toolCalls = response.choices[0]?.message?.tool_calls;
+    const fallbackCalls =
+      toolCalls?.length ? [] : this.extractToolCallsFromContent(messageContent);
+
+    if (toolCalls && toolCalls.length > 0) {
+      return toolCalls[0];
+    }
+
+    if (fallbackCalls.length > 0) {
+      return fallbackCalls[0];
+    }
+
+    return null;
+  }
+
+  private shouldUseToolRouter(): boolean {
+    const flag = process.env.H1DR4_TOOL_ROUTER;
+    if (!flag) {
+      return false;
+    }
+    return flag.toLowerCase() === "on" || flag.toLowerCase() === "true";
+  }
+
+  private appendToolResultMessage(
+    toolCall: H1dr4ToolCall,
+    result: ToolResult
+  ): void {
+    const content = result.success
+      ? result.output || "Success"
+      : result.error || "Error";
+    const provider = this.h1dr4Client.getProvider();
+    if (provider === "ollama") {
+      this.messages.push({
+        role: "tool",
+        name: toolCall.function.name,
+        content,
+      } as any);
+      return;
+    }
+
+    this.messages.push({
+      role: "tool",
+      content,
+      tool_call_id: toolCall.id,
+    } as any);
   }
 
   getChatHistory(): ChatEntry[] {

--- a/src/h1dr4/client.ts
+++ b/src/h1dr4/client.ts
@@ -1,5 +1,6 @@
 import OpenAI from "openai";
 import type { ChatCompletionMessageParam } from "openai/resources/chat";
+import axios from "axios";
 
 export type H1dr4Message = ChatCompletionMessageParam;
 
@@ -49,16 +50,47 @@ export interface H1dr4Response {
   }>;
 }
 
+export interface H1dr4RequestOptions {
+  temperature?: number;
+  max_tokens?: number;
+  tool_choice?: "auto" | "required" | { type: "function"; function: { name: string } };
+}
+
+type ProviderType = "grok" | "ollama";
+
 export class H1dr4Client {
-  private client: OpenAI;
+  private client?: OpenAI;
   private currentModel: string = "grok-3-latest";
+  private provider: ProviderType;
+  private ollamaBaseURL: string;
+  private requestTimeoutMs: number = 20000;
 
   constructor(apiKey: string, model?: string, baseURL?: string) {
-    this.client = new OpenAI({
-      apiKey,
-      baseURL: baseURL || process.env.GROK_BASE_URL || "https://api.x.ai/v1",
-      timeout: 360000,
-    });
+    this.provider =
+      process.env.H1DR4_PROVIDER?.toLowerCase() === "ollama"
+        ? "ollama"
+        : "grok";
+    this.ollamaBaseURL =
+      baseURL || process.env.OLLAMA_BASE_URL || "http://localhost:11434";
+    if (process.env.H1DR4_HTTP_TIMEOUT_MS) {
+      const parsed = Number.parseInt(process.env.H1DR4_HTTP_TIMEOUT_MS, 10);
+      if (!Number.isNaN(parsed)) {
+        this.requestTimeoutMs = parsed;
+      }
+    }
+
+    if (this.provider === "ollama") {
+      this.currentModel =
+        process.env.H1DR4_MODEL || "closex/neuraldaredevil-8b-abliterated:Q6_K";
+    }
+
+    if (this.provider === "grok") {
+      this.client = new OpenAI({
+        apiKey,
+        baseURL: baseURL || process.env.GROK_BASE_URL || "https://api.x.ai/v1",
+        timeout: 360000,
+      });
+    }
     if (model) {
       this.currentModel = model;
     }
@@ -72,13 +104,22 @@ export class H1dr4Client {
     return this.currentModel;
   }
 
+  getProvider(): ProviderType {
+    return this.provider;
+  }
+
   async chat(
     messages: H1dr4Message[],
     tools?: H1dr4Tool[],
     model?: string,
-    searchOptions?: SearchOptions
+    searchOptions?: SearchOptions,
+    requestOptions?: H1dr4RequestOptions
   ): Promise<H1dr4Response> {
     try {
+      if (this.provider === "ollama") {
+        return await this.chatOllama(messages, tools, model, requestOptions);
+      }
+
       const requestPayload: any = {
         model: model || this.currentModel,
         messages,
@@ -87,6 +128,16 @@ export class H1dr4Client {
         temperature: 0.7,
         max_tokens: 4000,
       };
+
+      if (requestOptions?.temperature !== undefined) {
+        requestPayload.temperature = requestOptions.temperature;
+      }
+      if (requestOptions?.max_tokens !== undefined) {
+        requestPayload.max_tokens = requestOptions.max_tokens;
+      }
+      if (requestOptions?.tool_choice !== undefined) {
+        requestPayload.tool_choice = requestOptions.tool_choice;
+      }
 
       // Add search parameters if specified
       if (searchOptions?.search_parameters) {
@@ -107,9 +158,15 @@ export class H1dr4Client {
     messages: H1dr4Message[],
     tools?: H1dr4Tool[],
     model?: string,
-    searchOptions?: SearchOptions
+    searchOptions?: SearchOptions,
+    requestOptions?: H1dr4RequestOptions
   ): AsyncGenerator<any, void, unknown> {
     try {
+      if (this.provider === "ollama") {
+        yield* this.chatStreamOllama(messages, tools, model, requestOptions);
+        return;
+      }
+
       const requestPayload: any = {
         model: model || this.currentModel,
         messages,
@@ -119,6 +176,16 @@ export class H1dr4Client {
         max_tokens: 4000,
         stream: true,
       };
+
+      if (requestOptions?.temperature !== undefined) {
+        requestPayload.temperature = requestOptions.temperature;
+      }
+      if (requestOptions?.max_tokens !== undefined) {
+        requestPayload.max_tokens = requestOptions.max_tokens;
+      }
+      if (requestOptions?.tool_choice !== undefined) {
+        requestPayload.tool_choice = requestOptions.tool_choice;
+      }
 
       // Add search parameters if specified
       if (searchOptions?.search_parameters) {
@@ -139,6 +206,21 @@ export class H1dr4Client {
 
   async reason(prompt: string, model?: string): Promise<string> {
     try {
+      if (this.provider === "ollama") {
+        const response = await this.chat(
+          [
+            {
+              role: "system",
+              content: "Provide a detailed, thoughtful response.",
+            },
+            { role: "user", content: prompt },
+          ],
+          [],
+          model
+        );
+        return response.choices[0]?.message?.content || "";
+      }
+
       const response: any = await (this.client as any).responses.create({
         model: model || this.currentModel,
         input: prompt,
@@ -154,6 +236,10 @@ export class H1dr4Client {
     query: string,
     searchParameters?: SearchParameters
   ): Promise<H1dr4Response> {
+    if (this.provider === "ollama") {
+      throw new Error("Search is not supported for the Ollama provider.");
+    }
+
     const searchMessage: H1dr4Message = {
       role: "user",
       content: query,
@@ -164,5 +250,182 @@ export class H1dr4Client {
     };
 
     return this.chat([searchMessage], [], undefined, searchOptions);
+  }
+
+  private normalizeOllamaToolCalls(
+    toolCalls: any[]
+  ): H1dr4ToolCall[] | undefined {
+    if (!toolCalls || toolCalls.length === 0) {
+      return undefined;
+    }
+
+    return toolCalls.map((call, index) => {
+      const functionCall = call.function || call;
+      const args = functionCall.arguments ?? call.arguments ?? {};
+      return {
+        id: call.id || `ollama-${Date.now()}-${index}`,
+        type: "function",
+        function: {
+          name: functionCall.name || "",
+          arguments:
+            typeof args === "string" ? args : JSON.stringify(args ?? {}),
+        },
+      };
+    });
+  }
+
+  private async chatOllama(
+    messages: H1dr4Message[],
+    tools?: H1dr4Tool[],
+    model?: string,
+    requestOptions?: H1dr4RequestOptions
+  ): Promise<H1dr4Response> {
+    const numPredict =
+      requestOptions?.max_tokens !== undefined
+        ? requestOptions.max_tokens
+        : 4000;
+    const preparedMessages = this.prepareOllamaMessages(messages);
+    const payload: any = {
+      model: model || this.currentModel,
+      messages: preparedMessages,
+      stream: false,
+      tools: tools || [],
+      options: {
+        temperature:
+          requestOptions?.temperature !== undefined
+            ? requestOptions.temperature
+            : 0.7,
+        num_predict: numPredict,
+      },
+    };
+
+    const response = await axios.post(
+      `${this.ollamaBaseURL}/api/chat`,
+      payload,
+      { timeout: this.requestTimeoutMs }
+    );
+
+    const message = response.data?.message || {};
+    const toolCalls = this.normalizeOllamaToolCalls(message.tool_calls);
+
+    return {
+      choices: [
+        {
+          message: {
+            role: message.role || "assistant",
+            content: message.content ?? "",
+            tool_calls: toolCalls,
+          },
+          finish_reason: toolCalls && toolCalls.length > 0 ? "tool_calls" : "stop",
+        },
+      ],
+    };
+  }
+
+  private async *chatStreamOllama(
+    messages: H1dr4Message[],
+    tools?: H1dr4Tool[],
+    model?: string,
+    requestOptions?: H1dr4RequestOptions
+  ): AsyncGenerator<any, void, unknown> {
+    const numPredict =
+      requestOptions?.max_tokens !== undefined
+        ? requestOptions.max_tokens
+        : 4000;
+    const preparedMessages = this.prepareOllamaMessages(messages);
+    const payload: any = {
+      model: model || this.currentModel,
+      messages: preparedMessages,
+      stream: true,
+      tools: tools || [],
+      options: {
+        temperature:
+          requestOptions?.temperature !== undefined
+            ? requestOptions.temperature
+            : 0.7,
+        num_predict: numPredict,
+      },
+    };
+
+    const response = await axios.post(
+      `${this.ollamaBaseURL}/api/chat`,
+      payload,
+      { timeout: this.requestTimeoutMs, responseType: "stream" }
+    );
+
+    const stream = response.data;
+    let buffer = "";
+
+    for await (const chunk of stream) {
+      buffer += chunk.toString();
+      const lines = buffer.split("\n");
+      buffer = lines.pop() || "";
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        const data = JSON.parse(trimmed);
+        const message = data.message || {};
+        const toolCalls = this.normalizeOllamaToolCalls(message.tool_calls);
+
+        if (data.done) {
+          yield {
+            choices: [
+              {
+                delta: {},
+                finish_reason: "stop",
+              },
+            ],
+          };
+          continue;
+        }
+
+        const delta: any = {};
+        if (message.content) {
+          delta.content = message.content;
+        }
+        if (toolCalls) {
+          delta.tool_calls = toolCalls;
+        }
+
+        yield {
+          choices: [
+            {
+              delta,
+            },
+          ],
+        };
+      }
+    }
+  }
+
+  private prepareOllamaMessages(messages: H1dr4Message[]): any[] {
+    return messages.map((message: any) => {
+      if (!message.tool_calls) {
+        return message;
+      }
+      const toolCalls = message.tool_calls.map((call: any) => {
+        const args = call.function?.arguments ?? call.arguments ?? {};
+        let parsedArgs = args;
+        if (typeof args === "string") {
+          try {
+            parsedArgs = JSON.parse(args);
+          } catch {
+            parsedArgs = {};
+          }
+        }
+        return {
+          type: "function",
+          function: {
+            name: call.function?.name || call.name,
+            arguments: parsedArgs ?? {},
+          },
+        };
+      });
+      return {
+        ...message,
+        tool_calls: toolCalls,
+      };
+    });
   }
 }

--- a/src/h1dr4/tools.ts
+++ b/src/h1dr4/tools.ts
@@ -326,7 +326,7 @@ const BASE_H1DR4_TOOLS: H1dr4Tool[] = [
     function: {
       name: "live_search",
       description:
-        "Search real-time web, news, and X posts using Grok's live search",
+        "Search the live web via DuckDuckGo, optionally fetch pages, and return citations + excerpts",
       parameters: {
         type: "object",
         properties: {
@@ -334,23 +334,62 @@ const BASE_H1DR4_TOOLS: H1dr4Tool[] = [
             type: "string",
             description: "Search query for live data",
           },
-          search_parameters: {
-            type: "object",
-            description:
-              "Optional live search parameters (defaults to auto mode with all sources)",
-            properties: {
-              mode: {
-                type: "string",
-                enum: ["auto", "on", "off"],
-              },
-              from_date: { type: "string" },
-              to_date: { type: "string" },
-              max_search_results: { type: "number" },
-              return_citations: { type: "boolean" },
-            },
+          max_results: {
+            type: "number",
+            description: "Maximum number of results to return (default: 5)",
+          },
+          fetch_pages: {
+            type: "boolean",
+            description: "Whether to fetch result pages for extraction (default: true)",
+          },
+          max_chars_per_page: {
+            type: "number",
+            description: "Maximum characters to keep per fetched page (default: 8000)",
+          },
+          region: {
+            type: "string",
+            description: "DuckDuckGo region code (default: wt-wt)",
+          },
+          safe: {
+            type: "string",
+            enum: ["on", "moderate", "off"],
+            description: "Safe search setting (default: moderate)",
           },
         },
         required: ["query"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "shannon",
+      description:
+        "Run Shannon's autonomous pentesting CLI (start, logs, query, stop) against a local or remote target",
+      parameters: {
+        type: "object",
+        properties: {
+          command: {
+            type: "string",
+            description:
+              "Shannon CLI command string, e.g. \"start URL=https://app REPO=/path\" or \"logs\"",
+          },
+          working_directory: {
+            type: "string",
+            description:
+              "Optional directory where the Shannon repo is located (defaults to current directory)",
+          },
+          env: {
+            type: "object",
+            description: "Optional environment variables for the Shannon process",
+            additionalProperties: { type: "string" },
+          },
+          timeout_ms: {
+            type: "number",
+            description: "Optional timeout in milliseconds (default 120000)",
+          },
+        },
+        required: ["command"],
       },
     },
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,10 @@ function loadApiKey(): string | undefined {
 }
 
 // Load base URL from user settings if not in environment
-function loadBaseURL(): string {
+function loadBaseURL(provider: string): string {
+  if (provider === "ollama") {
+    return process.env.OLLAMA_BASE_URL || "http://localhost:11434";
+  }
   const manager = getSettingsManager();
   return manager.getBaseURL();
 }
@@ -145,6 +148,31 @@ function loadModel(): string | undefined {
   }
 
   return model;
+}
+
+function getProvider(): string {
+  return (process.env.H1DR4_PROVIDER || "grok").toLowerCase();
+}
+
+function resolveMaxToolRounds(
+  provider: string,
+  maxToolRoundsOption?: string
+): number {
+  const optionValue = maxToolRoundsOption
+    ? parseInt(maxToolRoundsOption, 10)
+    : NaN;
+  if (!Number.isNaN(optionValue) && optionValue > 0) {
+    return optionValue;
+  }
+
+  const envValue = process.env.MAX_TOOL_ITERS
+    ? parseInt(process.env.MAX_TOOL_ITERS, 10)
+    : NaN;
+  if (!Number.isNaN(envValue) && envValue > 0) {
+    return envValue;
+  }
+
+  return provider === "ollama" ? 8 : 400;
 }
 
 // Handle commit-and-push command in headless mode
@@ -354,14 +382,17 @@ program
   )
   .version("1.0.1")
   .option("-d, --directory <dir>", "set working directory", process.cwd())
-  .option("-k, --api-key <key>", "Grok API key (or set GROK_API_KEY env var)")
+  .option(
+    "-k, --api-key <key>",
+    "API key (Grok/OpenAI providers; or set GROK_API_KEY env var)"
+  )
   .option(
     "-u, --base-url <url>",
-    "Grok API base URL (or set GROK_BASE_URL env var)"
+    "API base URL (Grok via GROK_BASE_URL or Ollama via OLLAMA_BASE_URL)"
   )
   .option(
     "-m, --model <model>",
-    "AI model to use (e.g., gemini-2.5-pro, grok-4-latest) (or set H1DR4_MODEL env var)"
+    "AI model to use (e.g., grok-4-latest, huihui_ai/qwen2.5-coder-abliterate:7b) (or set H1DR4_MODEL env var)"
   )
   .option(
     "-p, --prompt <prompt>",
@@ -369,8 +400,7 @@ program
   )
   .option(
     "--max-tool-rounds <rounds>",
-    "maximum number of tool execution rounds (default: 400)",
-    "400"
+    "maximum number of tool execution rounds (default: 8 for Ollama, 400 otherwise)"
   )
   .action(async (options) => {
     if (options.directory) {
@@ -386,32 +416,42 @@ program
     }
 
     try {
+      const provider = getProvider();
       // Get API key from options, environment, or user settings
       const apiKey = options.apiKey || loadApiKey();
-      const baseURL = options.baseUrl || loadBaseURL();
+      const baseURL = options.baseUrl || loadBaseURL(provider);
       const model = options.model || loadModel();
-      const maxToolRounds = parseInt(options.maxToolRounds) || 400;
+      const maxToolRounds = resolveMaxToolRounds(
+        provider,
+        options.maxToolRounds
+      );
 
-      if (!apiKey) {
+      if (!apiKey && provider !== "ollama") {
         console.error(
-          "❌ Error: API key required. Set GROK_API_KEY environment variable, use --api-key flag, or save to ~/.h1dr4/user-settings.json"
+          "❌ Error: API key required. Set GROK_API_KEY, use --api-key flag, or save to ~/.h1dr4/user-settings.json"
         );
         process.exit(1);
       }
 
       // Save API key and base URL to user settings if provided via command line
-      if (options.apiKey || options.baseUrl) {
+      if (provider !== "ollama" && (options.apiKey || options.baseUrl)) {
         await saveCommandLineSettings(options.apiKey, options.baseUrl);
       }
 
       // Headless mode: process prompt and exit
       if (options.prompt) {
-        await processPromptHeadless(options.prompt, apiKey, baseURL, model, maxToolRounds);
+        await processPromptHeadless(
+          options.prompt,
+          apiKey || "",
+          baseURL,
+          model,
+          maxToolRounds
+        );
         return;
       }
 
       // Interactive mode: launch UI
-      const agent = new H1dr4Agent(apiKey, baseURL, model, maxToolRounds);
+      const agent = new H1dr4Agent(apiKey || "", baseURL, model, maxToolRounds);
       console.log("🤖 Starting H1dr4 CLI Conversational Assistant...\n");
 
       ensureUserSettingsDirectory();
@@ -434,19 +474,21 @@ gitCommand
   .command("commit-and-push")
   .description("Generate AI commit message and push to remote")
   .option("-d, --directory <dir>", "set working directory", process.cwd())
-  .option("-k, --api-key <key>", "Grok API key (or set GROK_API_KEY env var)")
+  .option(
+    "-k, --api-key <key>",
+    "API key (Grok/OpenAI providers; or set GROK_API_KEY env var)"
+  )
   .option(
     "-u, --base-url <url>",
-    "Grok API base URL (or set GROK_BASE_URL env var)"
+    "API base URL (Grok via GROK_BASE_URL or Ollama via OLLAMA_BASE_URL)"
   )
   .option(
     "-m, --model <model>",
-    "AI model to use (e.g., gemini-2.5-pro, grok-4-latest) (or set H1DR4_MODEL env var)"
+    "AI model to use (e.g., grok-4-latest, huihui_ai/qwen2.5-coder-abliterate:7b) (or set H1DR4_MODEL env var)"
   )
   .option(
     "--max-tool-rounds <rounds>",
-    "maximum number of tool execution rounds (default: 400)",
-    "400"
+    "maximum number of tool execution rounds (default: 8 for Ollama, 400 otherwise)"
   )
   .action(async (options) => {
     if (options.directory) {
@@ -462,25 +504,34 @@ gitCommand
     }
 
     try {
+      const provider = getProvider();
       // Get API key from options, environment, or user settings
       const apiKey = options.apiKey || loadApiKey();
-      const baseURL = options.baseUrl || loadBaseURL();
+      const baseURL = options.baseUrl || loadBaseURL(provider);
       const model = options.model || loadModel();
-      const maxToolRounds = parseInt(options.maxToolRounds) || 400;
+      const maxToolRounds = resolveMaxToolRounds(
+        provider,
+        options.maxToolRounds
+      );
 
-      if (!apiKey) {
+      if (!apiKey && provider !== "ollama") {
         console.error(
-          "❌ Error: API key required. Set GROK_API_KEY environment variable, use --api-key flag, or save to ~/.h1dr4/user-settings.json"
+          "❌ Error: API key required. Set GROK_API_KEY, use --api-key flag, or save to ~/.h1dr4/user-settings.json"
         );
         process.exit(1);
       }
 
       // Save API key and base URL to user settings if provided via command line
-      if (options.apiKey || options.baseUrl) {
+      if (provider !== "ollama" && (options.apiKey || options.baseUrl)) {
         await saveCommandLineSettings(options.apiKey, options.baseUrl);
       }
 
-      await handleCommitAndPushHeadless(apiKey, baseURL, model, maxToolRounds);
+      await handleCommitAndPushHeadless(
+        apiKey || "",
+        baseURL,
+        model,
+        maxToolRounds
+      );
     } catch (error: any) {
       console.error("❌ Error during git commit-and-push:", error.message);
       process.exit(1);

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -7,3 +7,5 @@ export { SearchTool } from "./search";
 export { OSINTTool } from "./osint";
 export { ReasoningWorker } from "./reasoning-worker";
 export { GdeltTool } from "./gdelt";
+export { LiveSearchTool } from "./live-search";
+export { ShannonTool } from "./shannon";

--- a/src/tools/live-search.ts
+++ b/src/tools/live-search.ts
@@ -1,0 +1,265 @@
+import axios from "axios";
+import * as cheerio from "cheerio";
+import { ToolResult } from "../types";
+
+export interface LiveSearchOptions {
+  query: string;
+  max_results?: number;
+  fetch_pages?: boolean;
+  max_chars_per_page?: number;
+  region?: string;
+  safe?: "on" | "moderate" | "off";
+}
+
+interface LiveSearchResult {
+  title: string;
+  url: string;
+  snippet?: string;
+  source: "duckduckgo";
+  fetched?: boolean;
+  content_text?: string;
+  content_excerpt?: string;
+}
+
+interface LiveSearchResponse {
+  query: string;
+  results: LiveSearchResult[];
+  citations: Array<{ index: number; url: string; title: string }>;
+}
+
+const DEFAULT_TIMEOUT_MS = 10000;
+const MIN_DELAY_MS = 200;
+const MAX_DELAY_MS = 400;
+const MAX_CONCURRENCY = 3;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function randomDelay(): Promise<void> {
+  const delay =
+    MIN_DELAY_MS + Math.floor(Math.random() * (MAX_DELAY_MS - MIN_DELAY_MS + 1));
+  return sleep(delay);
+}
+
+function normalizeDuckDuckGoUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname.includes("duckduckgo.com")) {
+      const target = parsed.searchParams.get("uddg");
+      if (target) {
+        return decodeURIComponent(target);
+      }
+    }
+  } catch {
+    return url;
+  }
+  return url;
+}
+
+function cleanText(text: string): string {
+  return text.replace(/\s+/g, " ").trim();
+}
+
+function extractReadableText(html: string): string {
+  const $ = cheerio.load(html);
+  $("script, style, nav, footer, header, noscript, svg, iframe, canvas").remove();
+
+  const article = $("article").first();
+  if (article.length) {
+    return cleanText(article.text());
+  }
+
+  const main = $("main").first();
+  if (main.length) {
+    return cleanText(main.text());
+  }
+
+  const paragraphs = $("p")
+    .map((_, el) => cleanText($(el).text()))
+    .get()
+    .filter(Boolean);
+  if (paragraphs.length > 0) {
+    return paragraphs.join("\n");
+  }
+
+  return cleanText($("body").text());
+}
+
+function toExcerpt(text: string, maxChars: number): string {
+  if (!text) return "";
+  const trimmed = text.slice(0, maxChars);
+  return trimmed;
+}
+
+function safeSearchParam(safe: "on" | "moderate" | "off"): string {
+  if (safe === "off") {
+    return "-1";
+  }
+  return "1";
+}
+
+export class LiveSearchTool {
+  async search(options: LiveSearchOptions): Promise<ToolResult> {
+    try {
+      const query = options.query?.trim();
+      if (!query) {
+        return { success: false, error: "Query is required for live_search" };
+      }
+
+      const maxResults = Math.max(1, options.max_results ?? 5);
+      const fetchPages = options.fetch_pages ?? true;
+      const maxChars = Math.max(1000, options.max_chars_per_page ?? 8000);
+      const region = options.region ?? "wt-wt";
+      const safe = options.safe ?? "moderate";
+
+      const searchUrl = new URL("https://duckduckgo.com/html/");
+      searchUrl.searchParams.set("q", query);
+      searchUrl.searchParams.set("kl", region);
+      searchUrl.searchParams.set("kp", safeSearchParam(safe));
+
+      const response = await axios.get(searchUrl.toString(), {
+        timeout: DEFAULT_TIMEOUT_MS,
+        headers: {
+          "User-Agent":
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+          Accept: "text/html",
+        },
+        validateStatus: (status) => status >= 200 && status < 400,
+      });
+
+      const $ = cheerio.load(response.data);
+      const results: LiveSearchResult[] = [];
+
+      $("div.result, div.results > div").each((_, element) => {
+        if (results.length >= maxResults) {
+          return;
+        }
+
+        const linkEl = $(element).find("a.result__a, a.result__url, a").first();
+        const title = cleanText(linkEl.text());
+        const rawUrl = linkEl.attr("href") || "";
+        if (!rawUrl) {
+          return;
+        }
+
+        const url = normalizeDuckDuckGoUrl(rawUrl);
+        const snippet = cleanText(
+          $(element)
+            .find(".result__snippet, .result__body, .snippet")
+            .first()
+            .text()
+        );
+
+        results.push({
+          title: title || url,
+          url,
+          snippet: snippet || undefined,
+          source: "duckduckgo",
+        });
+      });
+
+      if (results.length === 0) {
+        const fallbackUrl = new URL("https://html.duckduckgo.com/html/");
+        fallbackUrl.searchParams.set("q", query);
+        fallbackUrl.searchParams.set("kl", region);
+        fallbackUrl.searchParams.set("kp", safeSearchParam(safe));
+        const fallbackResponse = await axios.get(fallbackUrl.toString(), {
+          timeout: DEFAULT_TIMEOUT_MS,
+          headers: {
+            "User-Agent":
+              "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+            Accept: "text/html",
+          },
+        });
+        const $$ = cheerio.load(fallbackResponse.data);
+        $$("div.result").each((_, element) => {
+          if (results.length >= maxResults) {
+            return;
+          }
+          const linkEl = $$(element).find("a.result__a").first();
+          const title = cleanText(linkEl.text());
+          const rawUrl = linkEl.attr("href") || "";
+          if (!rawUrl) {
+            return;
+          }
+          const url = normalizeDuckDuckGoUrl(rawUrl);
+          const snippet = cleanText($$(element).find(".result__snippet").first().text());
+          results.push({
+            title: title || url,
+            url,
+            snippet: snippet || undefined,
+            source: "duckduckgo",
+          });
+        });
+      }
+
+      if (fetchPages && results.length > 0) {
+        const queue = results.slice(0, maxResults);
+        const workers = Array.from(
+          { length: Math.min(MAX_CONCURRENCY, queue.length) },
+          async () => {
+            while (queue.length > 0) {
+              const item = queue.shift();
+              if (!item) return;
+              await randomDelay();
+              try {
+                const pageResponse = await axios.get(item.url, {
+                  timeout: DEFAULT_TIMEOUT_MS,
+                  headers: {
+                    "User-Agent":
+                      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+                  },
+                  maxRedirects: 5,
+                });
+
+                const contentType =
+                  pageResponse.headers["content-type"] || "";
+                if (!contentType.includes("text/html")) {
+                  item.fetched = false;
+                  continue;
+                }
+
+                const text = extractReadableText(pageResponse.data);
+                if (!text) {
+                  item.fetched = false;
+                  continue;
+                }
+
+                const truncated = text.slice(0, maxChars);
+                item.fetched = true;
+                item.content_text = truncated;
+                item.content_excerpt = toExcerpt(truncated, Math.min(500, maxChars));
+              } catch {
+                item.fetched = false;
+              }
+            }
+          }
+        );
+
+        await Promise.all(workers);
+      }
+
+      const payload: LiveSearchResponse = {
+        query,
+        results,
+        citations: results.map((result, index) => ({
+          index,
+          url: result.url,
+          title: result.title,
+        })),
+      };
+
+      return {
+        success: true,
+        output: JSON.stringify(payload, null, 2),
+        data: payload,
+      };
+    } catch (error: any) {
+      return {
+        success: false,
+        error: `Live search error: ${error.message}`,
+      };
+    }
+  }
+}

--- a/src/tools/shannon.ts
+++ b/src/tools/shannon.ts
@@ -1,0 +1,90 @@
+import { exec } from "child_process";
+import { promisify } from "util";
+import { ToolResult } from "../types";
+import { ConfirmationService } from "../utils/confirmation-service";
+import path from "path";
+import fs from "fs";
+
+const execAsync = promisify(exec);
+const DEFAULT_TIMEOUT_MS = 120000;
+
+export interface ShannonOptions {
+  command: string;
+  working_directory?: string;
+  env?: Record<string, string>;
+  timeout_ms?: number;
+}
+
+function resolveShannonPath(workingDirectory?: string): string {
+  if (process.env.SHANNON_PATH) {
+    return process.env.SHANNON_PATH;
+  }
+
+  const cwd = workingDirectory || process.cwd();
+  const localPath = path.join(cwd, "shannon");
+  if (fs.existsSync(localPath)) {
+    return localPath;
+  }
+
+  return "shannon";
+}
+
+export class ShannonTool {
+  private confirmationService = ConfirmationService.getInstance();
+
+  async run(options: ShannonOptions): Promise<ToolResult> {
+    try {
+      const command = options.command?.trim();
+      if (!command) {
+        return { success: false, error: "command is required for shannon tool" };
+      }
+
+      const shannonPath = resolveShannonPath(options.working_directory);
+      const fullCommand = `${shannonPath} ${command}`;
+
+      const sessionFlags = this.confirmationService.getSessionFlags();
+      if (!sessionFlags.bashCommands && !sessionFlags.allOperations) {
+        const confirmationResult =
+          await this.confirmationService.requestConfirmation(
+            {
+              operation: "Run Shannon CLI",
+              filename: fullCommand,
+              showVSCodeOpen: false,
+              content: `Command: ${fullCommand}\nWorking directory: ${
+                options.working_directory || process.cwd()
+              }`,
+            },
+            "bash"
+          );
+
+        if (!confirmationResult.confirmed) {
+          return {
+            success: false,
+            error: confirmationResult.feedback || "Shannon command cancelled",
+          };
+        }
+      }
+
+      const { stdout, stderr } = await execAsync(fullCommand, {
+        cwd: options.working_directory || process.cwd(),
+        timeout: options.timeout_ms ?? DEFAULT_TIMEOUT_MS,
+        maxBuffer: 1024 * 1024,
+        env: {
+          ...process.env,
+          ...(options.env || {}),
+        },
+      });
+
+      const output = stdout + (stderr ? `\nSTDERR: ${stderr}` : "");
+      return {
+        success: true,
+        output: output.trim() || "Shannon command executed successfully",
+      };
+    } catch (error: any) {
+      return {
+        success: false,
+        error: `Shannon command failed: ${error.message}`,
+      };
+    }
+  }
+}

--- a/src/tools/todo-tool.ts
+++ b/src/tools/todo-tool.ts
@@ -90,7 +90,7 @@ export class TodoTool extends EventEmitter {
         }
       }
 
-      // Build todo list asynchronously so updates can stream in
+      // Build todo list and emit a single update to avoid duplicated UI output
       for (const todo of todos) {
         const fullTodo = todo as TodoItem;
         const existingIndex = this.todos.findIndex((t) => t.id === fullTodo.id);
@@ -101,10 +101,8 @@ export class TodoTool extends EventEmitter {
           // Append new todo
           this.todos.push(fullTodo);
         }
-        this.emit('todo_update', this.formatTodoList());
-        // Yield to event loop to allow updates/interruption
-        await new Promise((resolve) => setTimeout(resolve, 0));
       }
+      this.emit('todo_update', this.formatTodoList());
 
       return {
         success: true,


### PR DESCRIPTION
### Motivation
- Reduce request latency by avoiding an extra model round-trip for tool routing unless explicitly enabled via `H1DR4_TOOL_ROUTER`.
- Preserve existing inline JSON fallback parsing for tool calls so tool functionality and backward compatibility remain intact.
- Use provider-aware defaults and optimizations to make local Ollama usage faster and more predictable.

### Description
- Add `shouldUseToolRouter()` and gate calls to `selectToolCallUsingModel` so the additional LLM-based tool routing only runs when `H1DR4_TOOL_ROUTER=on|true` in `src/agent/h1dr4-agent.ts`.
- Introduce helper functions `extractToolCallsFromContent`, `selectToolCallUsingModel`, and `appendToolResultMessage` and integrate them into both streaming and non-streaming agent flows to centralize tool-call parsing and result appending.
- Add Ollama provider support and HTTP-based `chat`/`chatStream` paths with request normalization, provider detection, and provider-aware defaults (e.g., `maxToolRounds` of 8 for Ollama) in `src/h1dr4/client.ts`, `src/index.ts`, and agent constructor.
- Wire in new tools and UX updates including `LiveSearchTool` and `ShannonTool` plus exports and README/package metadata updates to support scraping-based live search and local Shannon CLI usage.

### Testing
- Ran `npm run typecheck` (`tsc --noEmit`) and type checking completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c75070ee8832ca5ebb75d96b34e4b)