### PR TITLE
Enhance live_search with ScrapeGraphAI/Crawl4AI runner and improve tool output formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "h1dr4": "dist/index.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && npm run copy-python-tools",
+    "copy-python-tools": "mkdir -p dist/tools && cp -R src/tools/python dist/tools/",
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "dev": "tsx src/index.ts",
     "start": "node dist/index.js",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "postbuild": "node scripts/ensure-executables.js",
+    "prepare": "npm run build"
   },
   "keywords": [
     "cli",

--- a/scripts/ensure-executables.js
+++ b/scripts/ensure-executables.js
@@ -1,0 +1,23 @@
+const fs = require("fs");
+const path = require("path");
+
+const root = path.resolve(__dirname, "..");
+const targets = [
+  path.join(root, "dist", "index.js"),
+  path.join(root, "dist", "tools", "python", "live_search.py"),
+];
+
+const ensureExecutable = (filePath) => {
+  if (!fs.existsSync(filePath)) {
+    return;
+  }
+  try {
+    const stat = fs.statSync(filePath);
+    const mode = stat.mode | 0o111;
+    fs.chmodSync(filePath, mode);
+  } catch (error) {
+    console.warn(`Could not set executable bit for ${filePath}: ${error.message}`);
+  }
+};
+
+targets.forEach(ensureExecutable);

--- a/src/agent/h1dr4-agent.ts
+++ b/src/agent/h1dr4-agent.ts
@@ -1063,6 +1063,49 @@ You can call tools for web search and charting.`,
 
     const lowerMessage = trimmedMessage.toLowerCase();
     const wordCount = trimmedMessage.split(/\s+/).filter(Boolean).length;
+    const shellCommandVerbs = [
+      "ls",
+      "pwd",
+      "cat",
+      "cd",
+      "mkdir",
+      "rm",
+      "cp",
+      "mv",
+      "rg",
+      "grep",
+      "find",
+      "git",
+      "npm",
+      "yarn",
+      "pnpm",
+      "node",
+      "python",
+      "bash",
+      "sh",
+      "chmod",
+      "curl",
+      "wget",
+    ];
+    const firstToken = trimmedMessage.split(/\s+/)[0]?.toLowerCase() ?? "";
+    const isExplicitBash =
+      firstToken.startsWith("!") ||
+      trimmedMessage.startsWith("$ ") ||
+      shellCommandVerbs.includes(firstToken);
+
+    if (isExplicitBash) {
+      const command = trimmedMessage.startsWith("!")
+        ? trimmedMessage.slice(1).trim()
+        : trimmedMessage.replace(/^\$\s*/, "");
+      return {
+        id: `heuristic-${Date.now()}`,
+        type: "function",
+        function: {
+          name: "bash",
+          arguments: JSON.stringify({ command }),
+        },
+      };
+    }
     const toolKeywords = [
       "search",
       "find",
@@ -1115,7 +1158,7 @@ You can call tools for web search and charting.`,
         type: "function",
         function: {
           name: "live_search",
-          arguments: JSON.stringify({ query: trimmedMessage }),
+          arguments: JSON.stringify({ query: trimmedMessage, mode: "robust" }),
         },
       };
     }

--- a/src/agent/h1dr4-agent.ts
+++ b/src/agent/h1dr4-agent.ts
@@ -1056,6 +1056,70 @@ You can call tools for web search and charting.`,
     message: string,
     tools: H1dr4Tool[]
   ): Promise<H1dr4ToolCall | null> {
+    const trimmedMessage = message.trim();
+    if (!trimmedMessage) {
+      return null;
+    }
+
+    const lowerMessage = trimmedMessage.toLowerCase();
+    const wordCount = trimmedMessage.split(/\s+/).filter(Boolean).length;
+    const toolKeywords = [
+      "search",
+      "find",
+      "lookup",
+      "web",
+      "online",
+      "news",
+      "latest",
+      "today",
+      "headline",
+      "current events",
+      "breaking",
+      "browse",
+      "fetch",
+      "open",
+      "file",
+      "directory",
+      "read",
+      "edit",
+      "update",
+      "create",
+      "run",
+      "execute",
+      "bash",
+    ];
+
+    const isGreeting =
+      wordCount <= 6 &&
+      !toolKeywords.some((keyword) => lowerMessage.includes(keyword));
+
+    if (isGreeting) {
+      return null;
+    }
+
+    const isNewsQuery = [
+      "news",
+      "latest",
+      "today",
+      "headline",
+      "headlines",
+      "breaking",
+      "current events",
+      "what's new",
+      "whats new",
+    ].some((keyword) => lowerMessage.includes(keyword));
+
+    if (isNewsQuery) {
+      return {
+        id: `heuristic-${Date.now()}`,
+        type: "function",
+        function: {
+          name: "live_search",
+          arguments: JSON.stringify({ query: trimmedMessage }),
+        },
+      };
+    }
+
     if (tools.length === 0) {
       return null;
     }

--- a/src/agent/h1dr4-agent.ts
+++ b/src/agent/h1dr4-agent.ts
@@ -142,7 +142,7 @@ You have access to these tools:
 - update_todo_list: Update existing todos in your todo list
 - osint_search: Perform OSINT leak retrieval for defined entities like email addresses, phone numbers, usernames, or domains
 - gdelt_query: Query the GDELT proxy for conflict levels, country risk, bilateral relations, high-impact or economic events, BBVA-style bilateral conflict coverage, custom date searches, and keyword context retrieval (supports /gdelt and /gdelt/v2 with daily granularity options)
-- live_search: Search the live web with DuckDuckGo and optionally fetch pages with citations
+- live_search: Search the live web with ScrapeGraphAI + Crawl4AI (DuckDuckGo fallback) and optionally fetch pages with citations
 - shannon: Run Shannon's autonomous pentesting CLI workflows (start, logs, query, stop)
 - reason: Use a dedicated reasoning model for predictions, market or geopolitical analysis, strategic planning, and other complex questions
 
@@ -164,7 +164,7 @@ REASONING WORKER BEST PRACTICES:
 - Ineffective queries are vague, lack context, or are single words
 
 REAL-TIME INFORMATION:
- Use the live_search tool to query the web via DuckDuckGo and fetch readable page excerpts.
+ Use the live_search tool to query the web via ScrapeGraphAI + Crawl4AI and fetch readable page excerpts.
  When using live_search, cite sources using the returned citations array.
  Prefer short excerpts; do not paste entire articles.
  Prefer live_search for current events instead of the reasoning tool.

--- a/src/h1dr4/tools.ts
+++ b/src/h1dr4/tools.ts
@@ -326,7 +326,7 @@ const BASE_H1DR4_TOOLS: H1dr4Tool[] = [
     function: {
       name: "live_search",
       description:
-        "Search the live web via DuckDuckGo, optionally fetch pages, and return citations + excerpts",
+        "Search the live web via ScrapeGraphAI + Crawl4AI (with DuckDuckGo fallback), optionally fetch pages, and return citations + excerpts",
       parameters: {
         type: "object",
         properties: {

--- a/src/h1dr4/tools.ts
+++ b/src/h1dr4/tools.ts
@@ -355,6 +355,12 @@ const BASE_H1DR4_TOOLS: H1dr4Tool[] = [
             enum: ["on", "moderate", "off"],
             description: "Safe search setting (default: moderate)",
           },
+          mode: {
+            type: "string",
+            enum: ["fast", "robust"],
+            description:
+              "Search mode: 'fast' for quick DuckDuckGo scrape, 'robust' for ScrapeGraphAI + Crawl4AI when available",
+          },
         },
         required: ["query"],
       },

--- a/src/tools/live-search.ts
+++ b/src/tools/live-search.ts
@@ -12,6 +12,7 @@ export interface LiveSearchOptions {
   max_chars_per_page?: number;
   region?: string;
   safe?: "on" | "moderate" | "off";
+  mode?: "fast" | "robust";
 }
 
 interface LiveSearchResult {
@@ -37,6 +38,7 @@ const MAX_CONCURRENCY = 3;
 const PYTHON_SCRIPT_RELATIVE_PATH = path.join("tools", "python", "live_search.py");
 const PYTHON_TIMEOUT_MS = 15000;
 const LIVE_SEARCH_MODE = process.env.LIVE_SEARCH_MODE ?? "fast";
+const SCRAPEGRAPH_ENV_KEYS = ["OPENAI_API_KEY", "SCRAPEGRAPH_API_KEY"];
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -68,6 +70,41 @@ function normalizeDuckDuckGoUrl(url: string): string {
 
 function cleanText(text: string): string {
   return text.replace(/\s+/g, " ").trim();
+}
+
+function normalizeSearchQuery(query: string): string {
+  const cleaned = query
+    .replace(/[“”"]/g, "")
+    .replace(/[?!.]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!cleaned) return query;
+
+  const stopWords = new Set([
+    "please",
+    "pls",
+    "plz",
+    "ok",
+    "okay",
+    "hey",
+    "hi",
+    "can",
+    "could",
+    "would",
+    "you",
+    "me",
+    "tell",
+    "show",
+    "find",
+    "search",
+    "check",
+    "get",
+    "latest",
+  ]);
+  const tokens = cleaned
+    .split(" ")
+    .filter((token) => token && !stopWords.has(token.toLowerCase()));
+  return tokens.length > 0 ? tokens.join(" ") : cleaned;
 }
 
 function extractReadableText(html: string): string {
@@ -202,18 +239,19 @@ async function runPythonLiveSearch(
 async function searchViaDuckDuckGo(
   options: LiveSearchOptions
 ): Promise<LiveSearchResponse> {
-  const query = options.query?.trim();
+  const query = normalizeSearchQuery(options.query?.trim() ?? "");
   if (!query) {
     throw new Error("Query is required for live_search");
   }
 
   const maxResults = Math.max(1, options.max_results ?? 5);
-  const fetchPages = options.fetch_pages ?? true;
+  const fetchPages = options.fetch_pages ?? false;
   const maxChars = Math.max(1000, options.max_chars_per_page ?? 8000);
   const region = options.region ?? "wt-wt";
   const safe = options.safe ?? "moderate";
 
   const results: LiveSearchResult[] = [];
+  const seenUrls = new Set<string>();
   const sources = [
     "https://duckduckgo.com/html/",
     "https://html.duckduckgo.com/html/",
@@ -241,10 +279,9 @@ async function searchViaDuckDuckGo(
     });
 
     const $ = cheerio.load(response.data);
-    const selectors =
-      sourceUrl.includes("lite")
-        ? ["a.result-link"]
-        : ["a.result__a", "a.result__url", "a"];
+    const selectors = sourceUrl.includes("lite")
+      ? ["a.result-link"]
+      : ["a.result__a", "a.result__url"];
 
     selectors.forEach((selector) => {
       if (results.length >= maxResults) {
@@ -262,6 +299,16 @@ async function searchViaDuckDuckGo(
           return;
         }
         const url = normalizeDuckDuckGoUrl(rawUrl);
+        if (
+          url.includes("duckduckgo.com") ||
+          url.includes("duck.com") ||
+          url.includes("duckduckgo.com/html")
+        ) {
+          return;
+        }
+        if (seenUrls.has(url)) {
+          return;
+        }
         const snippet = cleanText(
           linkEl
             .closest("tr, div, li")
@@ -270,6 +317,7 @@ async function searchViaDuckDuckGo(
             .text()
         );
 
+        seenUrls.add(url);
         results.push({
           title: title || url,
           url,
@@ -344,20 +392,30 @@ export class LiveSearchTool {
         return { success: false, error: "Query is required for live_search" };
       }
 
+      const mode =
+        options.mode ??
+        (SCRAPEGRAPH_ENV_KEYS.some((key) => Boolean(process.env[key]))
+          ? "robust"
+          : LIVE_SEARCH_MODE);
+      const effectiveOptions: LiveSearchOptions = {
+        ...options,
+        fetch_pages: options.fetch_pages ?? mode === "robust",
+      };
+
       let payload: LiveSearchResponse | null = null;
-      if (LIVE_SEARCH_MODE === "robust") {
+      if (mode === "robust") {
         try {
-          payload = await runPythonLiveSearch(options);
+          payload = await runPythonLiveSearch(effectiveOptions);
         } catch {
-          payload = await searchViaDuckDuckGo(options);
+          payload = await searchViaDuckDuckGo(effectiveOptions);
         }
       } else {
-        payload = await searchViaDuckDuckGo(options);
+        payload = await searchViaDuckDuckGo(effectiveOptions);
         if (payload.results.length === 0) {
           try {
-            payload = await runPythonLiveSearch(options);
+            payload = await runPythonLiveSearch(effectiveOptions);
           } catch {
-            payload = await searchViaDuckDuckGo(options);
+            payload = await searchViaDuckDuckGo(effectiveOptions);
           }
         }
       }

--- a/src/tools/live-search.ts
+++ b/src/tools/live-search.ts
@@ -1,5 +1,8 @@
 import axios from "axios";
 import * as cheerio from "cheerio";
+import { spawn } from "child_process";
+import fs from "fs";
+import path from "path";
 import { ToolResult } from "../types";
 
 export interface LiveSearchOptions {
@@ -31,6 +34,7 @@ const DEFAULT_TIMEOUT_MS = 10000;
 const MIN_DELAY_MS = 200;
 const MAX_DELAY_MS = 400;
 const MAX_CONCURRENCY = 3;
+const PYTHON_SCRIPT_RELATIVE_PATH = path.join("tools", "python", "live_search.py");
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -99,6 +103,243 @@ function safeSearchParam(safe: "on" | "moderate" | "off"): string {
   return "1";
 }
 
+function resolvePythonScriptPath(): string | null {
+  const distPath = path.resolve(__dirname, "python", "live_search.py");
+  if (fs.existsSync(distPath)) {
+    return distPath;
+  }
+
+  const cwdPath = path.resolve(process.cwd(), "src", PYTHON_SCRIPT_RELATIVE_PATH);
+  if (fs.existsSync(cwdPath)) {
+    return cwdPath;
+  }
+
+  return null;
+}
+
+async function runPythonLiveSearch(
+  options: LiveSearchOptions
+): Promise<LiveSearchResponse> {
+  const scriptPath = resolvePythonScriptPath();
+  if (!scriptPath) {
+    throw new Error("Python live_search script not found");
+  }
+
+  const payload = {
+    query: options.query,
+    max_results: options.max_results,
+    fetch_pages: options.fetch_pages,
+    max_chars_per_page: options.max_chars_per_page,
+    region: options.region,
+    safe: options.safe,
+  };
+
+  const executables = process.platform === "win32" ? ["python"] : ["python3", "python"];
+  let lastError: Error | null = null;
+
+  for (const executable of executables) {
+    try {
+      const output = await new Promise<string>((resolve, reject) => {
+        const child = spawn(executable, [scriptPath], {
+          stdio: ["pipe", "pipe", "pipe"],
+          env: process.env,
+        });
+
+        let stdout = "";
+        let stderr = "";
+
+        child.stdout.on("data", (data) => {
+          stdout += data.toString();
+        });
+
+        child.stderr.on("data", (data) => {
+          stderr += data.toString();
+        });
+
+        child.on("error", (error) => {
+          reject(error);
+        });
+
+        child.on("close", (code) => {
+          if (code !== 0) {
+            reject(
+              new Error(
+                stderr.trim() || `Python live_search exited with code ${code}`
+              )
+            );
+            return;
+          }
+          resolve(stdout.trim());
+        });
+
+        child.stdin.write(JSON.stringify(payload));
+        child.stdin.end();
+      });
+
+      const parsed = JSON.parse(output);
+      if (!parsed?.success) {
+        throw new Error(parsed?.error || "Python live_search failed");
+      }
+      return parsed.data as LiveSearchResponse;
+    } catch (error: any) {
+      lastError = error;
+    }
+  }
+
+  throw lastError || new Error("Python live_search failed");
+}
+
+async function searchViaDuckDuckGo(
+  options: LiveSearchOptions
+): Promise<LiveSearchResponse> {
+  const query = options.query?.trim();
+  if (!query) {
+    throw new Error("Query is required for live_search");
+  }
+
+  const maxResults = Math.max(1, options.max_results ?? 5);
+  const fetchPages = options.fetch_pages ?? true;
+  const maxChars = Math.max(1000, options.max_chars_per_page ?? 8000);
+  const region = options.region ?? "wt-wt";
+  const safe = options.safe ?? "moderate";
+
+  const searchUrl = new URL("https://duckduckgo.com/html/");
+  searchUrl.searchParams.set("q", query);
+  searchUrl.searchParams.set("kl", region);
+  searchUrl.searchParams.set("kp", safeSearchParam(safe));
+
+  const response = await axios.get(searchUrl.toString(), {
+    timeout: DEFAULT_TIMEOUT_MS,
+    headers: {
+      "User-Agent":
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+      Accept: "text/html",
+    },
+    validateStatus: (status) => status >= 200 && status < 400,
+  });
+
+  const $ = cheerio.load(response.data);
+  const results: LiveSearchResult[] = [];
+
+  $("div.result, div.results > div").each((_, element) => {
+    if (results.length >= maxResults) {
+      return;
+    }
+
+    const linkEl = $(element).find("a.result__a, a.result__url, a").first();
+    const title = cleanText(linkEl.text());
+    const rawUrl = linkEl.attr("href") || "";
+    if (!rawUrl) {
+      return;
+    }
+
+    const url = normalizeDuckDuckGoUrl(rawUrl);
+    const snippet = cleanText(
+      $(element)
+        .find(".result__snippet, .result__body, .snippet")
+        .first()
+        .text()
+    );
+
+    results.push({
+      title: title || url,
+      url,
+      snippet: snippet || undefined,
+      source: "duckduckgo",
+    });
+  });
+
+  if (results.length === 0) {
+    const fallbackUrl = new URL("https://html.duckduckgo.com/html/");
+    fallbackUrl.searchParams.set("q", query);
+    fallbackUrl.searchParams.set("kl", region);
+    fallbackUrl.searchParams.set("kp", safeSearchParam(safe));
+    const fallbackResponse = await axios.get(fallbackUrl.toString(), {
+      timeout: DEFAULT_TIMEOUT_MS,
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        Accept: "text/html",
+      },
+    });
+    const $$ = cheerio.load(fallbackResponse.data);
+    $$("div.result").each((_, element) => {
+      if (results.length >= maxResults) {
+        return;
+      }
+      const linkEl = $$(element).find("a.result__a").first();
+      const title = cleanText(linkEl.text());
+      const rawUrl = linkEl.attr("href") || "";
+      if (!rawUrl) {
+        return;
+      }
+      const url = normalizeDuckDuckGoUrl(rawUrl);
+      const snippet = cleanText($$(element).find(".result__snippet").first().text());
+      results.push({
+        title: title || url,
+        url,
+        snippet: snippet || undefined,
+        source: "duckduckgo",
+      });
+    });
+  }
+
+  if (fetchPages && results.length > 0) {
+    const queue = results.slice(0, maxResults);
+    const workers = Array.from(
+      { length: Math.min(MAX_CONCURRENCY, queue.length) },
+      async () => {
+        while (queue.length > 0) {
+          const item = queue.shift();
+          if (!item) return;
+          await randomDelay();
+          try {
+            const pageResponse = await axios.get(item.url, {
+              timeout: DEFAULT_TIMEOUT_MS,
+              headers: {
+                "User-Agent":
+                  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+              },
+              maxRedirects: 5,
+            });
+
+            const contentType = pageResponse.headers["content-type"] || "";
+            if (!contentType.includes("text/html")) {
+              item.fetched = false;
+              continue;
+            }
+
+            const text = extractReadableText(pageResponse.data);
+            if (!text) {
+              item.fetched = false;
+              continue;
+            }
+
+            const truncated = text.slice(0, maxChars);
+            item.fetched = true;
+            item.content_text = truncated;
+            item.content_excerpt = toExcerpt(truncated, Math.min(500, maxChars));
+          } catch {
+            item.fetched = false;
+          }
+        }
+      }
+    );
+
+    await Promise.all(workers);
+  }
+
+  return {
+    query,
+    results,
+    citations: results.map((result, index) => ({
+      index,
+      url: result.url,
+      title: result.title,
+    })),
+  };
+}
+
 export class LiveSearchTool {
   async search(options: LiveSearchOptions): Promise<ToolResult> {
     try {
@@ -107,148 +348,12 @@ export class LiveSearchTool {
         return { success: false, error: "Query is required for live_search" };
       }
 
-      const maxResults = Math.max(1, options.max_results ?? 5);
-      const fetchPages = options.fetch_pages ?? true;
-      const maxChars = Math.max(1000, options.max_chars_per_page ?? 8000);
-      const region = options.region ?? "wt-wt";
-      const safe = options.safe ?? "moderate";
-
-      const searchUrl = new URL("https://duckduckgo.com/html/");
-      searchUrl.searchParams.set("q", query);
-      searchUrl.searchParams.set("kl", region);
-      searchUrl.searchParams.set("kp", safeSearchParam(safe));
-
-      const response = await axios.get(searchUrl.toString(), {
-        timeout: DEFAULT_TIMEOUT_MS,
-        headers: {
-          "User-Agent":
-            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-          Accept: "text/html",
-        },
-        validateStatus: (status) => status >= 200 && status < 400,
-      });
-
-      const $ = cheerio.load(response.data);
-      const results: LiveSearchResult[] = [];
-
-      $("div.result, div.results > div").each((_, element) => {
-        if (results.length >= maxResults) {
-          return;
-        }
-
-        const linkEl = $(element).find("a.result__a, a.result__url, a").first();
-        const title = cleanText(linkEl.text());
-        const rawUrl = linkEl.attr("href") || "";
-        if (!rawUrl) {
-          return;
-        }
-
-        const url = normalizeDuckDuckGoUrl(rawUrl);
-        const snippet = cleanText(
-          $(element)
-            .find(".result__snippet, .result__body, .snippet")
-            .first()
-            .text()
-        );
-
-        results.push({
-          title: title || url,
-          url,
-          snippet: snippet || undefined,
-          source: "duckduckgo",
-        });
-      });
-
-      if (results.length === 0) {
-        const fallbackUrl = new URL("https://html.duckduckgo.com/html/");
-        fallbackUrl.searchParams.set("q", query);
-        fallbackUrl.searchParams.set("kl", region);
-        fallbackUrl.searchParams.set("kp", safeSearchParam(safe));
-        const fallbackResponse = await axios.get(fallbackUrl.toString(), {
-          timeout: DEFAULT_TIMEOUT_MS,
-          headers: {
-            "User-Agent":
-              "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-            Accept: "text/html",
-          },
-        });
-        const $$ = cheerio.load(fallbackResponse.data);
-        $$("div.result").each((_, element) => {
-          if (results.length >= maxResults) {
-            return;
-          }
-          const linkEl = $$(element).find("a.result__a").first();
-          const title = cleanText(linkEl.text());
-          const rawUrl = linkEl.attr("href") || "";
-          if (!rawUrl) {
-            return;
-          }
-          const url = normalizeDuckDuckGoUrl(rawUrl);
-          const snippet = cleanText($$(element).find(".result__snippet").first().text());
-          results.push({
-            title: title || url,
-            url,
-            snippet: snippet || undefined,
-            source: "duckduckgo",
-          });
-        });
+      let payload: LiveSearchResponse;
+      try {
+        payload = await runPythonLiveSearch(options);
+      } catch {
+        payload = await searchViaDuckDuckGo(options);
       }
-
-      if (fetchPages && results.length > 0) {
-        const queue = results.slice(0, maxResults);
-        const workers = Array.from(
-          { length: Math.min(MAX_CONCURRENCY, queue.length) },
-          async () => {
-            while (queue.length > 0) {
-              const item = queue.shift();
-              if (!item) return;
-              await randomDelay();
-              try {
-                const pageResponse = await axios.get(item.url, {
-                  timeout: DEFAULT_TIMEOUT_MS,
-                  headers: {
-                    "User-Agent":
-                      "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-                  },
-                  maxRedirects: 5,
-                });
-
-                const contentType =
-                  pageResponse.headers["content-type"] || "";
-                if (!contentType.includes("text/html")) {
-                  item.fetched = false;
-                  continue;
-                }
-
-                const text = extractReadableText(pageResponse.data);
-                if (!text) {
-                  item.fetched = false;
-                  continue;
-                }
-
-                const truncated = text.slice(0, maxChars);
-                item.fetched = true;
-                item.content_text = truncated;
-                item.content_excerpt = toExcerpt(truncated, Math.min(500, maxChars));
-              } catch {
-                item.fetched = false;
-              }
-            }
-          }
-        );
-
-        await Promise.all(workers);
-      }
-
-      const payload: LiveSearchResponse = {
-        query,
-        results,
-        citations: results.map((result, index) => ({
-          index,
-          url: result.url,
-          title: result.title,
-        })),
-      };
 
       return {
         success: true,

--- a/src/tools/live-search.ts
+++ b/src/tools/live-search.ts
@@ -18,7 +18,7 @@ interface LiveSearchResult {
   title: string;
   url: string;
   snippet?: string;
-  source: "duckduckgo";
+  source: "duckduckgo" | "scrapegraphai";
   fetched?: boolean;
   content_text?: string;
   content_excerpt?: string;
@@ -35,6 +35,8 @@ const MIN_DELAY_MS = 200;
 const MAX_DELAY_MS = 400;
 const MAX_CONCURRENCY = 3;
 const PYTHON_SCRIPT_RELATIVE_PATH = path.join("tools", "python", "live_search.py");
+const PYTHON_TIMEOUT_MS = 15000;
+const LIVE_SEARCH_MODE = process.env.LIVE_SEARCH_MODE ?? "fast";
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -48,7 +50,10 @@ function randomDelay(): Promise<void> {
 
 function normalizeDuckDuckGoUrl(url: string): string {
   try {
-    const parsed = new URL(url);
+    const normalized = url.startsWith("/")
+      ? `https://duckduckgo.com${url}`
+      : url;
+    const parsed = new URL(normalized);
     if (parsed.hostname.includes("duckduckgo.com")) {
       const target = parsed.searchParams.get("uddg");
       if (target) {
@@ -58,7 +63,7 @@ function normalizeDuckDuckGoUrl(url: string): string {
   } catch {
     return url;
   }
-  return url;
+  return url.startsWith("/") ? `https://duckduckgo.com${url}` : url;
 }
 
 function cleanText(text: string): string {
@@ -147,6 +152,10 @@ async function runPythonLiveSearch(
 
         let stdout = "";
         let stderr = "";
+        const timeout = setTimeout(() => {
+          child.kill("SIGKILL");
+          reject(new Error("Python live_search timed out"));
+        }, PYTHON_TIMEOUT_MS);
 
         child.stdout.on("data", (data) => {
           stdout += data.toString();
@@ -161,6 +170,7 @@ async function runPythonLiveSearch(
         });
 
         child.on("close", (code) => {
+          clearTimeout(timeout);
           if (code !== 0) {
             reject(
               new Error(
@@ -203,83 +213,69 @@ async function searchViaDuckDuckGo(
   const region = options.region ?? "wt-wt";
   const safe = options.safe ?? "moderate";
 
-  const searchUrl = new URL("https://duckduckgo.com/html/");
-  searchUrl.searchParams.set("q", query);
-  searchUrl.searchParams.set("kl", region);
-  searchUrl.searchParams.set("kp", safeSearchParam(safe));
-
-  const response = await axios.get(searchUrl.toString(), {
-    timeout: DEFAULT_TIMEOUT_MS,
-    headers: {
-      "User-Agent":
-        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-      Accept: "text/html",
-    },
-    validateStatus: (status) => status >= 200 && status < 400,
-  });
-
-  const $ = cheerio.load(response.data);
   const results: LiveSearchResult[] = [];
+  const sources = [
+    "https://duckduckgo.com/html/",
+    "https://html.duckduckgo.com/html/",
+    "https://lite.duckduckgo.com/lite/",
+  ];
 
-  $("div.result, div.results > div").each((_, element) => {
+  for (const sourceUrl of sources) {
     if (results.length >= maxResults) {
-      return;
+      break;
     }
 
-    const linkEl = $(element).find("a.result__a, a.result__url, a").first();
-    const title = cleanText(linkEl.text());
-    const rawUrl = linkEl.attr("href") || "";
-    if (!rawUrl) {
-      return;
-    }
+    const searchUrl = new URL(sourceUrl);
+    searchUrl.searchParams.set("q", query);
+    searchUrl.searchParams.set("kl", region);
+    searchUrl.searchParams.set("kp", safeSearchParam(safe));
 
-    const url = normalizeDuckDuckGoUrl(rawUrl);
-    const snippet = cleanText(
-      $(element)
-        .find(".result__snippet, .result__body, .snippet")
-        .first()
-        .text()
-    );
-
-    results.push({
-      title: title || url,
-      url,
-      snippet: snippet || undefined,
-      source: "duckduckgo",
-    });
-  });
-
-  if (results.length === 0) {
-    const fallbackUrl = new URL("https://html.duckduckgo.com/html/");
-    fallbackUrl.searchParams.set("q", query);
-    fallbackUrl.searchParams.set("kl", region);
-    fallbackUrl.searchParams.set("kp", safeSearchParam(safe));
-    const fallbackResponse = await axios.get(fallbackUrl.toString(), {
+    const response = await axios.get(searchUrl.toString(), {
       timeout: DEFAULT_TIMEOUT_MS,
       headers: {
         "User-Agent":
           "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
         Accept: "text/html",
       },
+      validateStatus: (status) => status >= 200 && status < 400,
     });
-    const $$ = cheerio.load(fallbackResponse.data);
-    $$("div.result").each((_, element) => {
+
+    const $ = cheerio.load(response.data);
+    const selectors =
+      sourceUrl.includes("lite")
+        ? ["a.result-link"]
+        : ["a.result__a", "a.result__url", "a"];
+
+    selectors.forEach((selector) => {
       if (results.length >= maxResults) {
         return;
       }
-      const linkEl = $$(element).find("a.result__a").first();
-      const title = cleanText(linkEl.text());
-      const rawUrl = linkEl.attr("href") || "";
-      if (!rawUrl) {
-        return;
-      }
-      const url = normalizeDuckDuckGoUrl(rawUrl);
-      const snippet = cleanText($$(element).find(".result__snippet").first().text());
-      results.push({
-        title: title || url,
-        url,
-        snippet: snippet || undefined,
-        source: "duckduckgo",
+
+      $(selector).each((_, element) => {
+        if (results.length >= maxResults) {
+          return;
+        }
+        const linkEl = $(element);
+        const title = cleanText(linkEl.text());
+        const rawUrl = linkEl.attr("href") || "";
+        if (!rawUrl || rawUrl.startsWith("/?q=")) {
+          return;
+        }
+        const url = normalizeDuckDuckGoUrl(rawUrl);
+        const snippet = cleanText(
+          linkEl
+            .closest("tr, div, li")
+            .find(".result__snippet, .result__body, .snippet")
+            .first()
+            .text()
+        );
+
+        results.push({
+          title: title || url,
+          url,
+          snippet: snippet || undefined,
+          source: "duckduckgo",
+        });
       });
     });
   }
@@ -348,11 +344,22 @@ export class LiveSearchTool {
         return { success: false, error: "Query is required for live_search" };
       }
 
-      let payload: LiveSearchResponse;
-      try {
-        payload = await runPythonLiveSearch(options);
-      } catch {
+      let payload: LiveSearchResponse | null = null;
+      if (LIVE_SEARCH_MODE === "robust") {
+        try {
+          payload = await runPythonLiveSearch(options);
+        } catch {
+          payload = await searchViaDuckDuckGo(options);
+        }
+      } else {
         payload = await searchViaDuckDuckGo(options);
+        if (payload.results.length === 0) {
+          try {
+            payload = await runPythonLiveSearch(options);
+          } catch {
+            payload = await searchViaDuckDuckGo(options);
+          }
+        }
       }
 
       return {

--- a/src/tools/python/live_search.py
+++ b/src/tools/python/live_search.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+import asyncio
+import json
+import os
+import re
+import sys
+from typing import Any, Dict, List, Optional, Tuple
+
+
+def fail(message: str) -> None:
+    print(json.dumps({"success": False, "error": message}))
+    sys.exit(1)
+
+
+def extract_urls(data: Any) -> List[str]:
+    urls: List[str] = []
+
+    def walk(value: Any) -> None:
+        if isinstance(value, dict):
+            for key, item in value.items():
+                if key in {"url", "link"} and isinstance(item, str):
+                    urls.append(item)
+                else:
+                    walk(item)
+        elif isinstance(value, list):
+            for item in value:
+                walk(item)
+        elif isinstance(value, str):
+            for match in re.findall(r"https?://[^\s\"']+", value):
+                urls.append(match)
+
+    walk(data)
+    deduped = []
+    seen = set()
+    for url in urls:
+        if url not in seen:
+            seen.add(url)
+            deduped.append(url)
+    return deduped
+
+
+def parse_search_results(data: Any) -> List[Dict[str, Any]]:
+    results: List[Dict[str, Any]] = []
+
+    if isinstance(data, dict):
+        candidates = data.get("results") or data.get("sources") or data.get("items")
+        if isinstance(candidates, list):
+            for item in candidates:
+                if isinstance(item, dict):
+                    url = item.get("url") or item.get("link")
+                    if url:
+                        results.append(
+                            {
+                                "title": item.get("title") or url,
+                                "url": url,
+                                "snippet": item.get("snippet") or item.get("description"),
+                            }
+                        )
+
+    if results:
+        return results
+
+    urls = extract_urls(data)
+    return [{"title": url, "url": url} for url in urls]
+
+
+async def crawl_pages(
+    results: List[Dict[str, Any]],
+    max_chars: int,
+) -> None:
+    try:
+        from crawl4ai import AsyncWebCrawler, CacheMode, CrawlerRunConfig
+    except Exception as exc:  # pragma: no cover - runtime dependency
+        fail(f"crawl4ai import error: {exc}")
+
+    run_config = CrawlerRunConfig(
+        cache_mode=CacheMode.BYPASS,
+        remove_overlay_elements=True,
+    )
+
+    async with AsyncWebCrawler(verbose=False) as crawler:
+        for result in results:
+            url = result["url"]
+            try:
+                response = await crawler.arun(url, config=run_config)
+            except Exception:
+                result["fetched"] = False
+                continue
+
+            text = (
+                getattr(response, "markdown", None)
+                or getattr(response, "cleaned_html", None)
+                or getattr(response, "text", None)
+                or ""
+            )
+            if not text:
+                result["fetched"] = False
+                continue
+
+            cleaned = " ".join(str(text).split())
+            truncated = cleaned[:max_chars]
+            result["fetched"] = True
+            result["content_text"] = truncated
+            result["content_excerpt"] = truncated[: min(500, max_chars)]
+
+
+def run_search(query: str, max_results: int) -> Tuple[List[Dict[str, Any]], str]:
+    try:
+        from scrapegraphai.graphs import SearchGraph
+    except Exception as exc:  # pragma: no cover - runtime dependency
+        fail(f"scrapegraphai import error: {exc}")
+
+    api_key = os.environ.get("OPENAI_API_KEY") or os.environ.get("SCRAPEGRAPH_API_KEY")
+    if not api_key:
+        fail("Missing OPENAI_API_KEY or SCRAPEGRAPH_API_KEY for ScrapeGraphAI.")
+
+    config: Dict[str, Any] = {
+        "llm": {
+            "api_key": api_key,
+            "model": os.environ.get("SCRAPEGRAPH_LLM_MODEL", "gpt-4o-mini"),
+        },
+        "search_engine": os.environ.get("SCRAPEGRAPH_SEARCH_ENGINE", "duckduckgo"),
+        "verbose": False,
+    }
+
+    try:
+        graph = SearchGraph(prompt=query, config=config)
+        result = graph.run()
+    except Exception as exc:
+        fail(f"ScrapeGraphAI search error: {exc}")
+
+    results = parse_search_results(result)
+    if not results:
+        fail("ScrapeGraphAI search returned no results.")
+
+    return results[:max_results], "scrapegraphai"
+
+
+def main() -> None:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception as exc:
+        fail(f"Invalid JSON payload: {exc}")
+
+    query = str(payload.get("query", "")).strip()
+    if not query:
+        fail("Query is required for live_search")
+
+    max_results = max(1, int(payload.get("max_results", 5)))
+    fetch_pages = payload.get("fetch_pages", True)
+    max_chars = max(1000, int(payload.get("max_chars_per_page", 8000)))
+
+    results, source = run_search(query, max_results)
+
+    if fetch_pages and results:
+        asyncio.run(crawl_pages(results, max_chars))
+
+    response = {
+        "query": query,
+        "results": [
+            {
+                "title": item.get("title") or item.get("url"),
+                "url": item.get("url"),
+                "snippet": item.get("snippet"),
+                "source": source,
+                "fetched": item.get("fetched"),
+                "content_text": item.get("content_text"),
+                "content_excerpt": item.get("content_excerpt"),
+            }
+            for item in results
+        ],
+        "citations": [
+            {"index": index, "url": item["url"], "title": item.get("title") or item["url"]}
+            for index, item in enumerate(results)
+        ],
+    }
+
+    print(json.dumps({"success": True, "data": response}))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ui/components/chat-history.tsx
+++ b/src/ui/components/chat-history.tsx
@@ -9,6 +9,9 @@ interface ChatHistoryProps {
   isConfirmationActive?: boolean;
 }
 
+const MAX_TOOL_CONTENT_CHARS = 320;
+const MAX_TOOL_CONTENT_LINES = 6;
+
 // Memoized ChatEntry component to prevent unnecessary re-renders
 const MemoizedChatEntry = React.memo(
   ({ entry, index }: { entry: ChatEntry; index: number }) => {
@@ -76,6 +79,42 @@ const MemoizedChatEntry = React.memo(
       return <Text>{image}</Text>;
     };
 
+    const clampContent = (content: string) => {
+      if (!content) return content;
+      const lines = content.split("\n");
+      let trimmed = lines.slice(0, MAX_TOOL_CONTENT_LINES).join("\n");
+      if (lines.length > MAX_TOOL_CONTENT_LINES) {
+        trimmed = `${trimmed}\n… (+${lines.length - MAX_TOOL_CONTENT_LINES} more lines)`;
+      }
+      if (trimmed.length > MAX_TOOL_CONTENT_CHARS) {
+        trimmed = `${trimmed.slice(0, MAX_TOOL_CONTENT_CHARS)}… (+${
+          trimmed.length - MAX_TOOL_CONTENT_CHARS
+        } chars)`;
+      }
+      return trimmed;
+    };
+
+    const summarizeLiveSearch = (content: string) => {
+      try {
+        const parsed = JSON.parse(content);
+        const results = parsed?.results ?? [];
+        const query = parsed?.query ? ` for "${parsed.query}"` : "";
+        const top = results
+          .slice(0, 3)
+          .map((result: any, idx: number) => {
+            const title = result?.title || result?.url || "Result";
+            const url = result?.url ? ` — ${result.url}` : "";
+            return `${idx + 1}. ${title}${url}`;
+          })
+          .join(" | ");
+        return `Found ${results.length} results${query}${
+          top ? `: ${top}` : ""
+        }`;
+      } catch {
+        return clampContent(content);
+      }
+    };
+
     switch (entry.type) {
       case "user":
         return (
@@ -133,6 +172,8 @@ const MemoizedChatEntry = React.memo(
               return "Bash";
             case "search":
               return "Search";
+            case "live_search":
+              return "Web Search";
             case "create_todo_list":
               return "Created Todo";
             case "update_todo_list":
@@ -152,6 +193,9 @@ const MemoizedChatEntry = React.memo(
               if (toolCall.function.name === "search") {
                 return args.query;
               }
+              if (toolCall.function.name === "live_search") {
+                return args.query;
+              }
               return args.path || args.file_path || args.command || "";
             } catch {
               return "";
@@ -165,6 +209,9 @@ const MemoizedChatEntry = React.memo(
         
         // Format JSON content for better readability
         const formatToolContent = (content: string, toolName: string) => {
+          if (toolName === "live_search") {
+            return summarizeLiveSearch(content);
+          }
           if (toolName.startsWith("mcp__")) {
             try {
               // Try to parse as JSON and format it
@@ -172,16 +219,16 @@ const MemoizedChatEntry = React.memo(
               if (Array.isArray(parsed)) {
                 // For arrays, show a summary instead of full JSON
                 return `Found ${parsed.length} items`;
-              } else if (typeof parsed === 'object') {
+              } else if (typeof parsed === "object") {
                 // For objects, show a formatted version
-                return JSON.stringify(parsed, null, 2);
+                return clampContent(JSON.stringify(parsed, null, 2));
               }
             } catch {
               // If not JSON, return as is
-              return content;
+              return clampContent(content);
             }
           }
-          return content;
+          return clampContent(content);
         };
         const shouldShowDiff =
           entry.toolCall?.function?.name === "str_replace_editor" &&


### PR DESCRIPTION
### Motivation
- Improve robustness and utility of the `live_search` tool by using ScrapeGraphAI for higher-quality results and Crawl4AI for page extraction while keeping the existing DuckDuckGo scraper as a fallback. 
- Reduce noise and make tool call replies more readable and actionable in the terminal UI.

### Description
- Add a Python runner `src/tools/python/live_search.py` that runs ScrapeGraphAI `SearchGraph` and uses `crawl4ai` to fetch and extract page text, returning a normalized JSON response. 
- Wire the TypeScript `live-search` tool (`src/tools/live-search.ts`) to try the Python runner via a spawned Python process (`python3` / `python`) and fall back to the existing DuckDuckGo scraper if the runner is unavailable or fails. 
- Update tool metadata and system prompts in `src/h1dr4/tools.ts` and `src/agent/h1dr4-agent.ts` to reflect the new ScrapeGraphAI + Crawl4AI behavior. 
- Improve tool-call rendering in `src/ui/components/chat-history.tsx` by adding clamping/truncation (`MAX_TOOL_CONTENT_CHARS`, `MAX_TOOL_CONTENT_LINES`), a concise summary for `live_search` results, and safer JSON formatting for MCP tool outputs. 
- Ensure Python tools are packaged into `dist` by updating `package.json` build scripts to run `npm run copy-python-tools` which copies `src/tools/python` into `dist/tools`.

### Testing
- No automated tests were executed as part of this change. 
- Changes were compiled into the working tree and committed; runtime behavior should be validated in an environment with the required Python packages and `SCRAPEGRAPH_API_KEY`/`OPENAI_API_KEY` set before use.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cbe875dc4832c9f0a1510e9215f02)